### PR TITLE
Fix ZK biometric employee add: form submit and user_id collision

### DIFF
--- a/biometric/templates/biometric/add_biometric_user.html
+++ b/biometric/templates/biometric/add_biometric_user.html
@@ -8,7 +8,12 @@
     </button>
 </div>
 <div class="oh-modal__dialog-body" id="biometricEmployeesModalBody">
-    <form hx-post="{%url 'add-biometric-user' device_id%}" id="biometricEmployeesForm" class="oh-profile-section pt-0">
+    <form
+        hx-post="{%url 'add-biometric-user' device_id%}"
+        hx-target="#objectCreateModalTarget"
+        id="biometricEmployeesForm"
+        class="oh-profile-section pt-0"
+    >
         {% csrf_token %}
         <div class="col-sm-12 col-md-12 col-lg-12">
             <div class="oh-input-group">

--- a/biometric/views.py
+++ b/biometric/views.py
@@ -1725,8 +1725,13 @@ def add_biometric_user(request, device_id):
                 )
                 conn = zk_device.connect()
                 conn.enable_device()
-                existing_uids = [user.uid for user in conn.get_users()]
-                existing_user_ids = [user.user_id for user in conn.get_users()]
+                # Fetch once: get_users() is a round trip to the device.
+                device_users = conn.get_users()
+                existing_uids = [user.uid for user in device_users]
+                # The device reports user_id as a string. Compare like with like,
+                # otherwise the guard below never detects a taken user_id and can
+                # hand out one that already belongs to an enrolled employee.
+                existing_user_ids = {str(user.user_id) for user in device_users}
                 uid = 1
                 user_id = 1000
                 employee_ids = request.POST.getlist("employee_ids")
@@ -1736,12 +1741,11 @@ def add_biometric_user(request, device_id):
                         employee_id=employee, device_id=device
                     ).first()
                     if existing_biometric_employee is None:
-                        while uid in existing_uids or user_id in existing_user_ids:
-                            user_id = int(user_id)
+                        while uid in existing_uids or str(user_id) in existing_user_ids:
                             uid += 1
                             user_id += 1
                         existing_uids.append(uid)
-                        existing_user_ids.append(user_id)
+                        existing_user_ids.add(str(user_id))
                         employee_name = employee.get_full_name()
                         conn.set_user(
                             uid=uid,


### PR DESCRIPTION
## Description

Two bugs prevented adding an employee to a ZKTeco device from the UI.

**1. The add-employee form never submitted.** It declared `hx-post` but no
`hx-target`, unlike every other modal form in the codebase, so htmx did not
bind to it. Clicking **Add** fell back to a native browser GET, which reloaded
the page — no request sent, no error shown, nothing saved.

**2. The next free device `user_id` could collide with an enrolled user.**
The guard compared an `int` against the strings the device returns:

```python
existing_user_ids = [user.user_id for user in conn.get_users()]
while uid in existing_uids or user_id in existing_user_ids:
