### PR TITLE
build: compile locale catalogs and stop serving stale compressed static

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN apt-get update \
         libffi8 \
         curl \
         netcat-openbsd \
+        gettext \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
@@ -65,6 +66,11 @@ WORKDIR /app
 
 # Copy application code
 COPY --chown=appuser:appuser . .
+
+# Compile gettext catalogs (.po -> .mo): nothing in the repo or the runtime
+# compiles them, so without this every non-English locale silently renders
+# English. Plain msgfmt, so no Django settings/DB are needed at build time.
+RUN find . -name '*.po' -execdir sh -c 'msgfmt "$1" -o "${1%.po}.mo"' _ {} \;
 
 # Copy entrypoint script
 COPY --chown=appuser:appuser docker/entrypoint.sh /entrypoint.sh

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -45,8 +45,17 @@ esac
 # Run migrations
 python manage.py migrate --noinput
 
-# Collect static files
-python manage.py collectstatic --noinput
+# Collect static files.
+#
+# --clear is deliberate: STATIC_ROOT is a named volume that outlives the image,
+# and plain collectstatic leaves anything it considers unmodified in place. With
+# CompressedStaticFilesStorage that includes the pre-compressed .gz/.br
+# siblings, so after an upgrade WhiteNoise happily served a previous release's
+# global.js.gz to every browser (which all send Accept-Encoding: gzip) while
+# curl, getting the identity encoding, saw the current file — JS functions
+# "not defined" and half-rendered pages that looked fine to any check that
+# bypassed static serving. Wiping first keeps what we serve equal to the image.
+python manage.py collectstatic --noinput --clear
 
 echo "Starting server..."
 exec "$@"


### PR DESCRIPTION
## Problem

Two independent issues make a Docker deployment serve assets that do not match the image.

**1. Locale catalogs are never compiled.** The repo ships `.po` files for 11 languages, gitignores `*.mo`, and neither the `Dockerfile` nor `docker/entrypoint.sh` runs `compilemessages`. Django needs the compiled `.mo` to translate anything, so **every non-English locale silently renders English** in a Docker install. Selecting a language appears to do nothing.

**2. Stale pre-compressed static after an upgrade.** `STATIC_ROOT` is a named volume that outlives the image, and plain `collectstatic` leaves anything it considers unmodified in place. With `CompressedStaticFilesStorage` that includes the `.gz`/`.br` siblings, which it never regenerates for a file it did not copy.

After upgrading, the volume kept a previous release's `global.js.gz` while `global.js` itself was current. WhiteNoise serves the compressed variant to anything sending `Accept-Encoding: gzip` — i.e. every browser. Result: dashboards died with `Uncaught ReferenceError: registerAutoRefresh is not defined`, thrown by a months-old asset, while widgets stayed as skeleton loaders.

The nasty part is that this is invisible to server-side verification: `curl` (identity encoding) and the Django test client both returned the *current* file, so a full crawl of every route came back green while the app was broken in browsers.

```
$ curl -s .../static/horilla_theme/assets/js/global.js | wc -c
4853                                  # current
$ curl -s -H 'Accept-Encoding: gzip' --compressed .../global.js | wc -c
3000                                  # previous release, no registerAutoRefresh
```

## Fix

* `Dockerfile`: install `gettext` and compile each `.po` next to itself with plain `msgfmt` — no Django settings or database needed at build time.
* `docker/entrypoint.sh`: `collectstatic --noinput --clear`, so what is served always matches the image.

## Verification

Both applied to a production deployment (~5300 static files, 11 locales):

* `--clear` costs about **7 seconds** on startup.
* After the change, the gzip variant and the identity variant return the same current file, and all 74 assets referenced by the dashboards return 200 as a browser requests them.
* Ukrainian renders instead of English once the catalogs are compiled in the image.

One note on `--clear`: WhiteNoise keeps an in-memory index of `STATIC_ROOT` built at startup, so clearing the directory under a running process makes it 500 on the deleted variants. That is fine here because the entrypoint runs before the server starts, but it is worth knowing if anyone runs `collectstatic --clear` by hand against a live container.
