### PR TITLE
fix: recruitment and onboarding pipelines render blank until a filter is applied

### DIFF
--- a/onboarding/templates/cbv/pipeline/onboarding/pipeline.html
+++ b/onboarding/templates/cbv/pipeline/onboarding/pipeline.html
@@ -12,6 +12,8 @@
     <div
         class="oh-wrapper"
         id="pipelineContainer"
+        hx-get="{% url 'cbv-pipeline-tab-onboarding' %}"
+        hx-trigger="load"
     >
     </div>
 

--- a/recruitment/templates/cbv/pipeline/pipeline.html
+++ b/recruitment/templates/cbv/pipeline/pipeline.html
@@ -49,6 +49,8 @@
     <div
         class="oh-wrapper"
         id="pipelineContainer"
+        hx-get="{% url 'cbv-pipeline-tab' %}"
+        hx-trigger="load"
     >
     </div>
 


### PR DESCRIPTION
## Problem

Both CBV pipeline pages render an empty `#pipelineContainer` and never fill it, so **the page stays blank until the user applies a filter**.

`recruitment/templates/cbv/pipeline/pipeline.html` (and the onboarding equivalent) loads only the nav:

```html
<div hx-get="{% url 'cbv-pipeline-nav' %}" hx-trigger="load"></div>
<div class="oh-wrapper" id="pipelineContainer"></div>
```

The only element that targets `#pipelineContainer` is the nav's filter form, which htmx fires on `submit`:

```html
<form id="filterForm" hx-get="/recruitment/cbv-pipeline-tab/" hx-target="#pipelineContainer" ...>
```

Nothing triggers it on load. I checked for an implicit trigger before changing anything — no JS submits `#filterForm` or `.navFilterForm` on page load — and the older non-CBV template (`recruitment/templates/pipeline/pipeline.html`) does give its container its own `hx-trigger="load"`, so the CBV rewrite simply lost it.

## Fix

Give the container its own `hx-get` + `hx-trigger="load"`, matching the older template.

## Verification

On a deployment with one recruitment, 7 stages and 2 candidates: the page went from empty to rendering the pipeline immediately on open, and `/recruitment/cbv-pipeline-tab/` (which already returned the correct markup when requested directly) is now actually requested. Same for the onboarding pipeline.
