### PR TITLE
fix: hidden required Summernote field silently blocks form submit

### DIFF
--- a/static/index/index.js
+++ b/static/index/index.js
@@ -1391,16 +1391,27 @@ $(document).on("htmx:afterSwap", function () {
     // reason) -- this handler fires on EVERY htmx swap anywhere on the page,
     // so a modal reopened more than once was hitting this repeatedly.
     $("[data-summernote]").each(function () {
-        if ($(this).next(".note-editor").length > 0) {
+        var $source = $(this);
+        if ($source.next(".note-editor").length > 0) {
             return;
         }
-        $(this).summernote({
+        // Summernote hides the field it is attached to. The browser cannot
+        // focus a hidden control to report a constraint violation, so a
+        // `required` one aborts the whole submit ("An invalid form control
+        // ... is not focusable") — no submit event, no request, and the Save
+        // button appears dead. Leave the required check to the server, which
+        // renders its error inline under the field.
+        this.removeAttribute("required");
+        $source.summernote({
             height: 300,
             codeviewFilter: false,
             codeviewIframeFilter: false,
             callbacks: {
                 onChange: function (contents) {
-                    $('[name="body"]').val(contents);
+                    // Write back to the edited field itself — targeting
+                    // [name="body"] pushed the text into an unrelated field
+                    // whenever the editor was attached to anything else.
+                    $source.val(contents);
                 },
             },
         });
@@ -1440,6 +1451,12 @@ function initializeSummernote(candId, searchWords) {
     if ($body.next(".note-editor").length > 0) {
         $body.summernote("destroy");
     }
+    // Same hidden-required trap as the [data-summernote] init above: the
+    // browser cannot report a violation on the hidden source field, so a
+    // `required` mail body silently blocks the whole form submit.
+    $body.each(function () {
+        this.removeAttribute("required");
+    });
     $body.summernote({
         hint: {
             mentions: mentions,


### PR DESCRIPTION
## Problem

Summernote hides the field it is attached to. A browser cannot focus a hidden control to report a constraint violation, so if that field is `required` and empty, **the whole submit is aborted silently**:

```
Uncaught ReferenceError is not the issue — the console shows:
An invalid form control with name='description' is not focusable.
```

No `submit` event fires, htmx never posts, and to the user the Save button simply does nothing. This hits every form with a `required` rich-text field — the recruitment form's `description` is one (`forms.Textarea(attrs={"data-summernote": ""})` on a field with `blank=False`).

I reproduced it in isolation with the shipped `index.js`, the modal fragment and real static assets:

```js
$('[data-summernote]').summernote('code', '');   // empty description
form.requestSubmit();
// → form_valid: false
// → invalid: [{tag:'TEXTAREA', name:'description', hidden:true, msg:'Please fill out this field.'}]
// → submit_event_fired: false
```

## Fix

Drop the `required` attribute when Summernote takes over the field (both init sites: the `htmx:afterSwap` handler and `initializeSummernote`). Server-side validation still applies and Django returns the error keyed to the field, which renders inline — so nothing becomes silently optional, the error just becomes *visible* instead of blocking.

Verified after the change: `submit_event_fired: true` even with an empty editor, and the server responds with `{'description': ['This field is required.']}` shown under the field.

## Also in this commit

The generic `[data-summernote]` `onChange` callback wrote the editor contents into `$('[name="body"]')` regardless of which field the editor was attached to, so editing a *description* pushed text into an unrelated `body` field on the same page. It now writes back to the edited element itself.
