### PR TITLE
fix(attendance): unguarded helper calls abort hour_account.js and kill bulk actions

### DIFF
--- a/attendance/static/cbv/attendance/hour_account.js
+++ b/attendance/static/cbv/attendance/hour_account.js
@@ -1,14 +1,20 @@
-tickCheckboxes();
+if (typeof tickCheckboxes === "function") {
+    tickCheckboxes();
+}
 function makeListUnique(list) {
     return Array.from(new Set(list));
 }
 
-tickactivityCheckboxes();
+if (typeof tickactivityCheckboxes === "function") {
+    tickactivityCheckboxes();
+}
 function makeactivityListUnique(list) {
     return Array.from(new Set(list));
 }
 
-ticklatecomeCheckboxes();
+if (typeof ticklatecomeCheckboxes === "function") {
+    ticklatecomeCheckboxes();
+}
 function makelatecomeListUnique(list) {
     return Array.from(new Set(list));
 }


### PR DESCRIPTION
## Problem

`attendance/static/cbv/attendance/hour_account.js` calls three helpers at top level:

```js
tickCheckboxes();
tickactivityCheckboxes();
ticklatecomeCheckboxes();
```

They come from `attendance/static/attendance/actions.js`, which is not loaded on every page that pulls this file in. The resulting `ReferenceError` on line 1 **aborts the whole file**, so everything defined below it never exists — `hourAccountbulkDelete`, `lateComeBulkDelete`, `reqAttendanceBulkApprove`, `reqAttendanceBulkReject`. The list toolbar's bulk actions go dead with only a console error to show for it.

Seen on `/attendance/late-come-early-out-view/`:

```
Uncaught ReferenceError: tickCheckboxes is not defined
    at hour_account.js:1:1
```

## Fix

Wrap the three calls in the same `typeof` guard that `attendance/static/cbv/attendance_activity.js` already uses for the identical helpers:

```js
if (typeof tickCheckboxes === "function") {
    tickCheckboxes();
}
```

so the file finishes loading and the bulk handlers get defined regardless of which page included it.
