### PR TITLE
fix(leave): Leave Balances search ignores the surname

### DIFF
--- a/leave/filters.py
+++ b/leave/filters.py
@@ -70,9 +70,7 @@ class AssignedLeaveFilter(FilterSet):
     # leave_type = filters.CharFilter(
     #     field_name="leave_type_id__name", lookup_expr="icontains"
     # )
-    search = filters.CharFilter(
-        field_name="employee_id__employee_first_name", lookup_expr="icontains"
-    )
+    search = filters.CharFilter(method=filter_by_name)
     employee_id = django_filters.ModelMultipleChoiceFilter(
         queryset=Employee.objects.all(),
         widget=forms.SelectMultiple(),
@@ -347,9 +345,7 @@ class LeaveAllocationRequestFilter(FilterSet):
     leave_type = filters.CharFilter(
         field_name="leave_type_id__name", lookup_expr="icontains"
     )
-    search = filters.CharFilter(
-        field_name="employee_id__employee_first_name", lookup_expr="icontains"
-    )
+    search = filters.CharFilter(method=filter_by_name)
     number_of_days_up_to = filters.NumberFilter(
         field_name="requested_days", lookup_expr="lte"
     )


### PR DESCRIPTION
## Problem

`AssignedLeaveFilter` (Leave → **Leave Balances**) and `LeaveAllocationRequestFilter` search only the employee's **first** name:

```python
search = filters.CharFilter(
    field_name="employee_id__employee_first_name", lookup_expr="icontains"
)
```

So a surname never matches, and substrings of the given name match by accident — which looks like the filter breaking after a couple of characters. For an employee named *Oksana Saienko*:

```
search='Sa'       -> 3 rows   (matches "Ok-sa-na", "Lary-sa", "Olek-sa-ndr")
search='Sai'      -> 0 rows
search='Saienko'  -> 0 rows
```

## Fix

Use the shared `horilla.filters.filter_by_name`, exactly as the attendance, payroll and employee filters already do — it matches first + last name and the badge id. After the change:

```
search='Sai'             -> 1   Oksana Saienko
search='Saienko'         -> 1   Oksana Saienko
search='Oksana Saienko'  -> 1   Oksana Saienko
search='oksana-saienko'  -> 1   Oksana Saienko   (badge id)
```

`filter_by_name` was already imported in `leave/filters.py`, so this is a two-line change.
