### PR TITLE
fix(i18n): employee profile tab labels are never translated

### DIFF
--- a/horilla_theme/templates/generic/horilla_profile_view.html
+++ b/horilla_theme/templates/generic/horilla_profile_view.html
@@ -368,7 +368,8 @@
                                 data-tab="{{tab.title}}"
                                 class="bg-white {% if forloop.counter == 1 and not active_target %} active {% endif %}"
                             >
-                                {{ tab.title }}
+                                {# label only — data-tab and tab.url stay untranslated for routing #}
+                                {% trans tab.title %}
                             </button>
                             <span
                                 hx-get="{{tab.url|format:instance}}"


### PR DESCRIPTION
## Problem

`HorillaProfileView` renders its tab captions raw, so employee-profile tabs stay English in every locale:

```html
data-tab="{{tab.title}}"
...
{{ tab.title }}
```

## Fix

Translate the visible label only:

```html
{% trans tab.title %}
```

`data-tab` and the tab URL are deliberately left untranslated, because tab routing and the active-tab lookup match on them — translating those would break navigation.
