### PR TITLE
fix: /accounts/login/ returns 500 and the auth urlconf is included twice

### DIFF
--- a/horilla/urls.py
+++ b/horilla/urls.py
@@ -20,6 +20,7 @@ from django.core.cache import cache
 from django.db import connection
 from django.http import JsonResponse
 from django.urls import include, path, re_path
+from django.views.generic import RedirectView
 from django.views.i18n import JavaScriptCatalog
 
 import notifications.urls
@@ -63,7 +64,15 @@ def readiness_check(request):
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("accounts/", include("django.contrib.auth.urls")),
+    # django.contrib.auth.urls is here for the password_reset_* routes its forms
+    # and mails reverse. Its /accounts/login/ renders registration/login.html,
+    # which Horilla does not ship, so that one URL 500s — send it to the real
+    # login page instead. (The include was also listed twice.)
+    path(
+        "accounts/login/",
+        RedirectView.as_view(url=settings.LOGIN_URL, permanent=False),
+        name="accounts-login-redirect",
+    ),
     path("accounts/", include("django.contrib.auth.urls")),
     path("", include("base.urls")),
     path("", include("horilla_automations.urls")),


### PR DESCRIPTION
## Problem

Two small things in `horilla/urls.py`:

1. `django.contrib.auth.urls` is included **twice** (identical lines).
2. Its `/accounts/login/` view renders `registration/login.html`, a template Horilla does not ship, so a **publicly reachable URL returns 500** with `TemplateDoesNotExist`. The real login page is `/login/` (`LOGIN_URL = "/login"`).

Found by crawling every no-argument route on a deployment: out of ~1700 URLs this was one of only two 500s.

## Fix

Point that one path at `settings.LOGIN_URL` with a `RedirectView` and keep a single include, so the `password_reset_*` routes that `base.forms`' `PasswordResetForm` relies on stay available.

`reverse("login")` is unaffected: `base.urls` registers the same name later in the urlconf and already wins, which the existing `horilla_auth` tests depend on.

Verified: `/accounts/login/` now 302s to the login page; `password_reset` and friends still reverse.
