### PR TITLE
i18n(uk): complete the Ukrainian catalogs and fix strings no translation could reach

### DIFF
--- a/horilla/locale/uk/LC_MESSAGES/django.po
+++ b/horilla/locale/uk/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: Horilla\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2026-08-02 22:34+0530\n"
-"PO-Revision-Date: 2026-08-04 09:08+0000\n"
+"PO-Revision-Date: 2026-08-14 12:00+0300\n"
 "Last-Translator: SCG seed pipeline\n"
 "Language-Team: Ukrainian\n"
 "Language: uk\n"
@@ -117,20 +117,14 @@ msgstr "Активи"
 msgid "Asset Batch Number"
 msgstr "Номер партії активу"
 
-#, fuzzy
-#| msgid "Asset Batch Number"
 msgid "Create Batch Number"
-msgstr "Номер партії активу"
+msgstr "Створити номер партії"
 
-#, fuzzy
-#| msgid "Batch Number"
 msgid "Batch Number Update"
-msgstr "Номер партії"
+msgstr "Оновлення номера партії"
 
-#, fuzzy
-#| msgid "Batch number created successfully."
 msgid "Batch number updated successfully."
-msgstr "Номер партії успішно створено."
+msgstr "Номер партії успішно оновлено."
 
 msgid "Batch number created successfully."
 msgstr "Номер партії успішно створено."
@@ -141,15 +135,11 @@ msgstr "Деталі"
 msgid "Asset"
 msgstr "Актив"
 
-#, fuzzy
-#| msgid "Asset category description"
 msgid "Asset Category Creation"
-msgstr "Опис категорії активу"
+msgstr "Створення категорії активу"
 
-#, fuzzy
-#| msgid "Asset Category"
 msgid "Asset Category Update"
-msgstr "Категорія активу"
+msgstr "Оновлення категорії активу"
 
 msgid "Asset category updated successfully"
 msgstr "Категорію активу успішно оновлено"
@@ -157,44 +147,32 @@ msgstr "Категорію активу успішно оновлено"
 msgid "Asset category created successfully"
 msgstr "Категорію активу успішно створено"
 
-#, fuzzy
-#| msgid "Asset Information"
 msgid "Asset Creation"
-msgstr "Інформація про актив"
+msgstr "Створення активу"
 
-#, fuzzy
-#| msgid "Asset Updated"
 msgid "Asset Update"
-msgstr "Актив оновлено"
+msgstr "Оновлення активу"
 
-#, fuzzy
-#| msgid "Asset created successfully"
 msgid "Asset updated successfully"
-msgstr "Актив успішно створено"
+msgstr "Актив успішно оновлено"
 
 msgid "Asset created successfully"
 msgstr "Актив успішно створено"
 
-#, fuzzy
-#| msgid "Asset Categories"
 msgid "Asset Category Duplicate"
-msgstr "Категорії активів"
+msgstr "Копія категорії активу"
 
 msgid "Duplicate"
 msgstr "Дублювати"
 
-#, fuzzy
-#| msgid "Save Duplicate"
 msgid "Asset Duplicate"
-msgstr "Зберегти копію"
+msgstr "Копія активу"
 
 msgid "Add Asset Report"
 msgstr "Додати звіт по активу"
 
-#, fuzzy
-#| msgid "Report added successfully."
 msgid "Asset report added successfully."
-msgstr "Звіт успішно додано."
+msgstr "Звіт по активу успішно додано."
 
 msgid "Asset Category"
 msgstr "Категорія активу"
@@ -259,63 +237,41 @@ msgstr "Термін дії до"
 msgid "Return Date"
 msgstr "Дата повернення"
 
-#, fuzzy
-#| msgid "Allowance deleted successfully"
 msgid "Allocation deleted successfully"
-msgstr "Надбавку успішно видалено"
+msgstr "Призначення успішно видалено"
 
-#, fuzzy
-#| msgid "Asset deleted successfully"
 msgid "Asset request deleted successfully"
-msgstr "Актив успішно видалено"
+msgstr "Заявку на актив успішно видалено"
 
 msgid "Asset Allocation"
 msgstr "Видача активу"
 
-#, fuzzy
-#| msgid "Create allocation"
 msgid "Create Allocation"
 msgstr "Створити розподілення"
 
-#, fuzzy
-#| msgid "Asset View"
 msgid "Asset Renewal"
-msgstr "Перегляд активів"
+msgstr "Продовження активу"
 
-#, fuzzy
-#| msgid "Requested Employee"
 msgid "Asset Request / Employee"
-msgstr "Співробітник, який подав запит"
+msgstr "Заявка на актив / співробітник"
 
-#, fuzzy
-#| msgid "Asset Request Date"
 msgid "Asset Request / Asset Category"
-msgstr "Дата запиту на актив"
+msgstr "Заявка на актив / категорія активу"
 
-#, fuzzy
-#| msgid "Asset Request Date"
 msgid "Asset Request / Request Date"
-msgstr "Дата запиту на актив"
+msgstr "Заявка на актив / дата заявки"
 
-#, fuzzy
-#| msgid "Asset Request Date"
 msgid "Asset Request / Status"
-msgstr "Дата запиту на актив"
+msgstr "Заявка на актив / статус"
 
-#, fuzzy
-#| msgid "Asset Allocation"
 msgid "Asset Allocation / Employee"
-msgstr "Видача активу"
+msgstr "Видача активу / співробітник"
 
-#, fuzzy
-#| msgid "Asset Allocated Date"
 msgid "Asset Allocation / Assigned Date"
-msgstr "Дата видачі активу"
+msgstr "Видача активу / дата призначення"
 
-#, fuzzy
-#| msgid "Asset Allocated Date"
 msgid "Asset Allocation / Return Date"
-msgstr "Дата видачі активу"
+msgstr "Видача активу / дата повернення"
 
 msgid "Tracking Id"
 msgstr "Ідентифікатор відстеження"
@@ -323,8 +279,6 @@ msgstr "Ідентифікатор відстеження"
 msgid "Batch No"
 msgstr "Номер партії"
 
-#, fuzzy
-#| msgid "Assigned By"
 msgid "Assigned by"
 msgstr "Призначив(ла)"
 
@@ -340,58 +294,36 @@ msgstr "Опис запиту"
 msgid "You don't have permission."
 msgstr "У вас немає дозволу."
 
-#, fuzzy
-#| msgid "Request Updated Successfully"
 msgid "Asset Request Created Successfully"
-msgstr "Запит успішно оновлено"
+msgstr "Заявку на актив успішно створено"
 
-#, fuzzy
-#| msgid "Asset allocated successfully!."
 msgid "Asset allocated Successfully"
 msgstr "Актив успішно розподілено!."
 
-#, fuzzy
-#| msgid "Asset request approved successfully!"
 msgid "Asset request approved successfully!."
 msgstr "Запит на актив успішно затверджено!"
 
-#, fuzzy
-#| msgid "Days"
 msgid "Days Left"
-msgstr "Днів"
+msgstr "Залишилось днів"
 
-#, fuzzy
-#| msgid "Search in :Asset"
 msgid "Reassign Asset"
-msgstr "Пошук в: Актив"
+msgstr "Перепризначити актив"
 
-#, fuzzy
-#| msgid "Asset created successfully"
 msgid "Asset reassigned successfully."
-msgstr "Актив успішно створено"
+msgstr "Актив успішно перепризначено."
 
-#, fuzzy
-#| msgid "Expiry Date"
 msgid "Expiry Date From"
-msgstr "Термін дії до"
+msgstr "Дата закінчення з"
 
-#, fuzzy
-#| msgid "Expiry Date"
 msgid "Expiry Date To"
-msgstr "Термін дії до"
+msgstr "Дата закінчення до"
 
-#, fuzzy
-#| msgid "Assigned Date"
 msgid "Assigned Date From"
-msgstr "Дата призначення"
+msgstr "Дата призначення з"
 
-#, fuzzy
-#| msgid "Assigned Date"
 msgid "Assigned Date To"
-msgstr "Дата призначення"
+msgstr "Дата призначення до"
 
-#, fuzzy
-#| msgid "Asset status"
 msgid "Asset Status"
 msgstr "Статус активу"
 
@@ -405,7 +337,7 @@ msgid "Create new batch number"
 msgstr "Створити новий номер партії"
 
 msgid "Requesting a laptop for software development purposes."
-msgstr ""
+msgstr "Запит ноутбука для потреб розробки програмного забезпечення."
 
 msgid "on returns the laptop. However, it has suffered minor damage."
 msgstr "повертає ноутбук. Однак він має незначні пошкодження."
@@ -413,10 +345,8 @@ msgstr "повертає ноутбук. Однак він має незначн
 msgid "Return date cannot be in the future."
 msgstr "Дата повернення не може бути в майбутньому."
 
-#, fuzzy
-#| msgid "Selected Assets"
 msgid "Replacement Asset"
-msgstr "Вибрані активи"
+msgstr "Актив на заміну"
 
 msgid "Name"
 msgstr "Назва"
@@ -449,7 +379,7 @@ msgid "Cost"
 msgstr "Вартість"
 
 msgid "Quantity"
-msgstr ""
+msgstr "Кількість"
 
 msgid "Notify Before (days)"
 msgstr "Повідомити заздалегідь (днів)"
@@ -502,10 +432,8 @@ msgstr "Розподілено"
 msgid "Send Mail"
 msgstr "Надіслати листа"
 
-#, fuzzy
-#| msgid "Assign"
 msgid "Reassign"
-msgstr "Призначити"
+msgstr "Перепризначити"
 
 msgid "Requested"
 msgstr "Запитано"
@@ -541,7 +469,7 @@ msgid "Delete"
 msgstr "Видалити"
 
 msgid "trash outline"
-msgstr ""
+msgstr "trash outline"
 
 msgid "Close"
 msgstr "Закрити"
@@ -556,7 +484,7 @@ msgid "Import Assets"
 msgstr "Імпортувати активи"
 
 msgid "close outline"
-msgstr ""
+msgstr "close outline"
 
 msgid "Upload a File"
 msgstr "Завантажити файл"
@@ -571,13 +499,11 @@ msgid "Upload"
 msgstr "Завантажити"
 
 msgid "chevron back outline"
-msgstr ""
+msgstr "chevron back outline"
 
 msgid "chevron forward outline"
-msgstr ""
+msgstr "chevron forward outline"
 
-#, fuzzy
-#| msgid "Available"
 msgid "available"
 msgstr "Доступний"
 
@@ -593,10 +519,8 @@ msgstr "Перемкнути параметри"
 msgid "Edit"
 msgstr "Редагувати"
 
-#, fuzzy
-#| msgid "Available Days"
 msgid "Available / Total"
-msgstr "Доступні дні"
+msgstr "Доступно / Усього"
 
 msgid "Asset Report"
 msgstr "Звіт по активу"
@@ -640,10 +564,8 @@ msgstr "Звіт успішно додано."
 msgid "Assign asset before adding a report"
 msgstr "Перш ніж додавати звіт, призначте актив"
 
-#, fuzzy
-#| msgid "Dashboard"
 msgid "Asset Dashboard"
-msgstr "Дашборд"
+msgstr "Дашборд активів"
 
 msgid "Just now"
 msgstr "Просто зараз"
@@ -654,13 +576,11 @@ msgstr "Увімкнути автоматичне оновлення"
 msgid "This Month"
 msgstr "Цього місяця"
 
-#, fuzzy
-#| msgid "Reset Month"
 msgid "Last Month"
-msgstr "Місяць скидання"
+msgstr "Минулий місяць"
 
 msgid "Quarter"
-msgstr ""
+msgstr "Квартал"
 
 msgid "From"
 msgstr "Від"
@@ -668,84 +588,56 @@ msgstr "Від"
 msgid "To"
 msgstr "До"
 
-#, fuzzy
-#| msgid "Custom"
 msgid "Customize"
-msgstr "Custom"
+msgstr "Налаштувати"
 
 msgid "In use, available, unavailable"
-msgstr ""
+msgstr "Використовується, доступно, недоступно"
 
-#, fuzzy
-#| msgid "Request Date"
 msgid "Request Status"
-msgstr "Дата запиту"
+msgstr "Статус заявки"
 
-#, fuzzy
-#| msgid "Asset request"
 msgid "Asset requests"
-msgstr "Запит на актив"
+msgstr "Заявки на активи"
 
-#, fuzzy
-#| msgid "Asset Category"
 msgid "Assets by Category"
-msgstr "Категорія активу"
+msgstr "Активи за категоріями"
 
 msgid "In use vs available per category"
-msgstr ""
+msgstr "Використовується та доступно за категоріями"
 
-#, fuzzy
-#| msgid "Asset Category"
 msgid "Value by Category"
-msgstr "Категорія активу"
+msgstr "Вартість за категорією"
 
-#, fuzzy
-#| msgid "Asset purchase cost"
 msgid "Total purchase cost"
-msgstr "Вартість придбання активу"
+msgstr "Загальна вартість придбання"
 
-#, fuzzy
-#| msgid "Same Department"
 msgid "Assets by Department"
-msgstr "Той самий відділ"
+msgstr "Активи за відділами"
 
-#, fuzzy
-#| msgid "Manager assigned to the department"
 msgid "Allocated assets per department"
-msgstr "Менеджер, закріплений за відділом"
+msgstr "Видані активи за відділами"
 
-#, fuzzy
-#| msgid "Asset Name"
 msgid "Asset Age"
-msgstr "Назва активу"
+msgstr "Вік активу"
 
-#, fuzzy
-#| msgid "Employee Contribution"
 msgid "Fleet age distribution"
-msgstr "Внесок співробітника"
+msgstr "Розподіл віку парку"
 
 msgid "Expiring Soon"
-msgstr ""
+msgstr "Скоро спливає"
 
-#, fuzzy
-#| msgid "Next Holiday"
 msgid "Next 60 days"
-msgstr "Наступне свято"
+msgstr "Наступні 60 днів"
 
-#, fuzzy
-#| msgid "Uploading..."
 msgid "Loading..."
 msgstr "Завантаження..."
 
-#, fuzzy
-#| msgid "Recent actions"
 msgid "Recent Allocations"
-msgstr "Останні дії"
+msgstr "Останні призначення"
 
-#, fuzzy
-#| msgid "My Dashboard"
 msgid "Customize Dashboard"
-msgstr "Моя інформаційна панель"
+msgstr "Налаштувати дашборд"
 
 msgid "Reset"
 msgstr "Скинути"
@@ -756,89 +648,59 @@ msgstr "Автоматичне оновлення УВІМКНЕНО (5 хв)"
 msgid "Auto-refresh OFF"
 msgstr "Автоматичне оновлення ВИМКНЕНО"
 
-#, fuzzy
-#| msgid "Import Assets"
 msgid "Total Assets"
-msgstr "Імпортувати активи"
+msgstr "Всього активів"
 
-#, fuzzy
-#| msgid "In use"
 msgid "in use"
 msgstr "У використанні"
 
-#, fuzzy
-#| msgid "Pending Leaves Requests"
 msgid "Pending Requests"
-msgstr "Запити на відпустку в очікуванні"
+msgstr "Заявки в очікуванні"
 
-#, fuzzy
-#| msgid "Return Date"
 msgid "return req"
-msgstr "Дата повернення"
+msgstr "заявка на повернення"
 
-#, fuzzy
-#| msgid "Waiting Approval"
 msgid "Awaiting approval"
 msgstr "Очікує затвердження"
 
-#, fuzzy
-#| msgid "Start Value"
 msgid "Total Value"
-msgstr "Початкове значення"
+msgstr "Загальна вартість"
 
-#, fuzzy
-#| msgid "Purchase Cost"
 msgid "Purchase cost"
 msgstr "Вартість придбання"
 
-#, fuzzy
-#| msgid "Next Holiday"
 msgid "Next 30 days"
-msgstr "Наступне свято"
+msgstr "Наступні 30 днів"
 
 msgid "Could not load KPIs"
-msgstr ""
+msgstr "Не вдалося завантажити KPI"
 
-#, fuzzy
-#| msgid "asset"
 msgid "No assets"
-msgstr "актив"
+msgstr "Немає активів"
 
 msgid "Total"
 msgstr "Усього"
 
 msgid "Could not load data"
-msgstr ""
+msgstr "Не вдалося завантажити дані"
 
-#, fuzzy
-#| msgid "New Requests"
 msgid "No requests"
-msgstr "Нові запити"
+msgstr "Немає заявок"
 
-#, fuzzy
-#| msgid "To date"
 msgid "No data"
-msgstr "Дата до"
+msgstr "Немає даних"
 
-#, fuzzy
-#| msgid "Allocated Assets"
 msgid "No allocated assets"
-msgstr "Видані активи"
+msgstr "Немає виданих активів"
 
-#, fuzzy
-#| msgid "Asset purchase date"
 msgid "No purchase date data"
-msgstr "Дата придбання активу"
+msgstr "Немає даних про дату придбання"
 
-#, fuzzy
-#| msgid "Number of contracts expiring in "
 msgid "No assets expiring soon"
-msgstr "Кількість контрактів, що закінчуються у "
+msgstr "Немає активів, термін яких спливає"
 
-#, fuzzy
-#| msgid "Recent actions"
 msgid "No recent allocations"
-msgstr "Останні дії"
+msgstr "Немає нових призначень"
 
 msgid "Page not found. 404."
 msgstr "Сторінку не знайдено. 404."
@@ -886,7 +748,7 @@ msgid "Apply"
 msgstr "Застосувати"
 
 msgid "ellipsis vertical sharp"
-msgstr ""
+msgstr "ellipsis vertical sharp"
 
 msgid "Returned date"
 msgstr "Дата повернення"
@@ -909,10 +771,8 @@ msgstr "Фільтр"
 msgid "Group By"
 msgstr "Групувати за"
 
-#, fuzzy
-#| msgid "Field"
 msgid "Fields"
-msgstr "Поле"
+msgstr "Поля"
 
 msgid "Selected Assets"
 msgstr "Вибрані активи"
@@ -962,10 +822,8 @@ msgstr "Затвердити"
 msgid "Reject"
 msgstr "Відхилити"
 
-#, fuzzy
-#| msgid "Do you want to delete this Allowance?"
 msgid "Do you want to delete this Allocation?"
-msgstr "Ви бажаєте видалити цю надбавку?"
+msgstr "Ви бажаєте видалити це призначення?"
 
 msgid "Requested Employee"
 msgstr "Співробітник, який подав запит"
@@ -973,10 +831,8 @@ msgstr "Співробітник, який подав запит"
 msgid "Asset Request Date"
 msgstr "Дата запиту на актив"
 
-#, fuzzy
-#| msgid "Current User"
 msgid "Current Asset"
-msgstr "Поточний користувач"
+msgstr "Поточний актив"
 
 msgid "No assets have been assigned to you."
 msgstr "Вам не призначено жодних активів."
@@ -1047,10 +903,8 @@ msgstr "Запит на актив успішно затверджено!"
 msgid "An error occurred: "
 msgstr "Сталася помилка: "
 
-#, fuzzy
-#| msgid "Shift request not found."
 msgid "Asset request not found."
-msgstr "Запит на зміну не знайдено."
+msgstr "Заявку на актив не знайдено."
 
 msgid "Asset request has been rejected."
 msgstr "Запит на актив відхилено."
@@ -1058,26 +912,20 @@ msgstr "Запит на актив відхилено."
 msgid "Asset allocated successfully!."
 msgstr "Актив успішно розподілено!."
 
-#, fuzzy
-#| msgid "{rshift_assign} not found."
 msgid "Asset assignment not found."
-msgstr "{rshift_assign} не знайдено."
+msgstr "Призначення активу не знайдено."
 
 msgid "Return request for {} initiated."
 msgstr "Запит на повернення для {} ініційовано."
 
-#, fuzzy
-#| msgid "Asset Return Successful!."
 msgid "Asset Returned Successfully..."
-msgstr "Повернення активу успішне!."
+msgstr "Актив успішно повернено..."
 
 msgid "Asset Return Successful!."
 msgstr "Повернення активу успішне!."
 
-#, fuzzy
-#| msgid "Asset not found"
 msgid "Asset assignment not found"
-msgstr "Актив не знайдено"
+msgstr "Призначення активу не знайдено"
 
 msgid "Successfully imported Assets"
 msgstr "Активи успішно імпортовано"
@@ -1133,10 +981,8 @@ msgstr "Вихід"
 msgid "Out Date"
 msgstr "Дата виходу"
 
-#, fuzzy
-#| msgid "Duration:"
 msgid "Duration (HH:MM:SS)"
-msgstr "Тривалість:"
+msgstr "Тривалість (ГГ:ХХ:СС)"
 
 msgid "Shift Day"
 msgstr "День зміни"
@@ -1192,8 +1038,6 @@ msgstr "Затверджено"
 msgid "Bulk-Requests"
 msgstr "Масові запити"
 
-#, fuzzy
-#| msgid "Not validated"
 msgid "Not Validated"
 msgstr "Не підтверджено"
 
@@ -1212,25 +1056,17 @@ msgstr "Відвідування"
 msgid "Activities"
 msgstr "Активність"
 
-#, fuzzy
-#| msgid "New Attendances Request"
 msgid "New Attendance Request"
-msgstr "Новий запит на відвідуваність"
+msgstr "Нова заявка на відвідування"
 
-#, fuzzy
-#| msgid "Update Attendances Request"
 msgid "Update Attendance Request"
-msgstr "Оновити запит на відвідуваність"
+msgstr "Оновити заявку на відвідування"
 
-#, fuzzy
-#| msgid "New attendance request created"
 msgid "New Attendance request created"
 msgstr "Створено новий запит на відвідуваність"
 
-#, fuzzy
-#| msgid "New attendance request created"
 msgid "New Attendance request updated"
-msgstr "Створено новий запит на відвідуваність"
+msgstr "Нову заявку на відвідування оновлено"
 
 msgid "Attendance update request created."
 msgstr "Запит на оновлення відвідуваності створено."
@@ -1238,15 +1074,11 @@ msgstr "Запит на оновлення відвідуваності ство
 msgid "Create Attendance Request"
 msgstr "Створити запит на відвідуваність"
 
-#, fuzzy
-#| msgid "Validated Attendances"
 msgid "Validate Attendances"
-msgstr "Перевірені відвідування"
+msgstr "Перевірити відвідуваність"
 
-#, fuzzy
-#| msgid "Attendance Reports"
 msgid "Attendance Report"
-msgstr "Звіти по відвідуваності"
+msgstr "Звіт по відвідуваності"
 
 msgid "Pending Hour"
 msgstr "Очікувана година"
@@ -1257,39 +1089,29 @@ msgstr "Відвідуваність на підтвердження"
 msgid "Validate"
 msgstr "Перевірити"
 
-#, fuzzy
-#| msgid "OT Attendances"
 msgid " OT Attendances"
 msgstr "Понаднормові відвідування"
 
 msgid "Approve OT"
 msgstr "Затвердити понаднормові"
 
-#, fuzzy
-#| msgid "Validated Attendances"
 msgid " Validated Attendances"
 msgstr "Перевірені відвідування"
 
-#, fuzzy
-#| msgid "work_type"
 msgid "work_type_id"
-msgstr "тип роботи"
+msgstr "Тип роботи"
 
 msgid "Add Attendances"
 msgstr "Додати відвідування"
 
-#, fuzzy
-#| msgid "Attendance added."
 msgid "Attendance Added"
 msgstr "Відвідуваність додано."
 
 msgid "Edit Attendance"
 msgstr "Редагувати відвідування"
 
-#, fuzzy
-#| msgid "Attendance Updated."
 msgid "Attandance Updated"
-msgstr "Відвідуваність оновлено."
+msgstr "Відвідуваність оновлено"
 
 msgid "Leave Type"
 msgstr "Тип відпустки"
@@ -1297,10 +1119,8 @@ msgstr "Тип відпустки"
 msgid "Minus Days"
 msgstr "Мінус днів"
 
-#, fuzzy
-#| msgid "Deducted From "
 msgid "Deducted From CFD"
-msgstr "Утримано з "
+msgstr "Утримано з перенесених"
 
 msgid "Penalty amount"
 msgstr "Сума штрафу"
@@ -1308,15 +1128,11 @@ msgstr "Сума штрафу"
 msgid "Created Date"
 msgstr "Дата створення"
 
-#, fuzzy
-#| msgid "Payment Type"
 msgid "Penalty Type"
-msgstr "Тип оплати"
+msgstr "Тип штрафу"
 
-#, fuzzy
-#| msgid "Are you sure you want to delete this payslip?"
 msgid "Are you sure you want to delete this penalty?"
-msgstr "Ви впевнені, що бажаєте видалити цей розрахунковий листок?"
+msgstr "Ви впевнені, що хочете видалити цей штраф?"
 
 msgid "Attendance"
 msgstr "Відвідування"
@@ -1345,13 +1161,9 @@ msgstr "Автозатвердження понаднормових"
 msgid "Break Point Condition"
 msgstr "Умова точки перерви"
 
-#, fuzzy
-#| msgid "Create Attendance condition "
 msgid "Create Attendance condition"
 msgstr "Створити умову відвідуваності "
 
-#, fuzzy
-#| msgid "Update Attendance condition "
 msgid "Update Attendance condition"
 msgstr "Оновити умову відвідуваності "
 
@@ -1370,10 +1182,8 @@ msgstr "Увімкнути відмітку приходу/виходу"
 msgid "Worked Hours"
 msgstr "Відпрацьовані години"
 
-#, fuzzy
-#| msgid "Portal Status"
 msgid "Work Status"
-msgstr "Статус порталу"
+msgstr "Статус роботи"
 
 msgid "Allowed Time"
 msgstr "Дозволений час"
@@ -1388,7 +1198,7 @@ msgid "Assigned Shifts"
 msgstr "Призначені зміни"
 
 msgid "Is default"
-msgstr ""
+msgstr "За замовчуванням"
 
 msgid "Is active"
 msgstr "Активно"
@@ -1432,23 +1242,15 @@ msgstr "Непідтверджені понаднормові години"
 msgid "Employment Type"
 msgstr "Тип зайнятості"
 
-#, fuzzy
-#| msgid "Overtime"
 msgid "Over time"
 msgstr "Понаднормові"
 
-#, fuzzy
-#| msgid "Hour account deleted."
 msgid "Hour account update"
-msgstr "Рахунок годин видалено."
+msgstr "Оновлення рахунку годин"
 
-#, fuzzy
-#| msgid "Attendance account added."
 msgid "Attendance account updated"
-msgstr "Рахунок відвідуваності додано."
+msgstr "Рахунок відвідуваності оновлено"
 
-#, fuzzy
-#| msgid "Attendance account added."
 msgid "Attendance account added"
 msgstr "Рахунок відвідуваності додано."
 
@@ -1458,35 +1260,23 @@ msgstr "IP-адреси"
 msgid "Type"
 msgstr "Тип"
 
-#, fuzzy
-#| msgid "Penalties"
 msgid "Penalities"
 msgstr "Штрафи"
 
-#, fuzzy
-#| msgid "Late Come/Early Out"
 msgid "Late Come/Early Out "
 msgstr "Запізнення/Ранній вихід"
 
-#, fuzzy
-#| msgid "Minimum hour"
 msgid "Minimum Hour"
 msgstr "Мінімальна кількість годин"
 
-#, fuzzy
-#| msgid "Check-In Date"
 msgid "Chen-in Date"
 msgstr "Дата приходу"
 
-#, fuzzy
-#| msgid "Check-Out Date"
 msgid "Check-out Date"
 msgstr "Дата виходу"
 
-#, fuzzy
-#| msgid "Attendance Validate"
 msgid "Attendance Validated"
-msgstr "Перевірка відвідування"
+msgstr "Відвідуваність перевірено"
 
 msgid "Approved Request"
 msgstr "Затверджений запит"
@@ -1494,8 +1284,6 @@ msgstr "Затверджений запит"
 msgid "My Attendances"
 msgstr "Мої відвідування"
 
-#, fuzzy
-#| msgid "Check-In Date"
 msgid "Check-in Date"
 msgstr "Дата приходу"
 
@@ -1547,16 +1335,12 @@ msgstr "Це поле обов'язкове"
 msgid "Employee not chosen"
 msgstr "Співробітника не обрано"
 
-#, fuzzy
-#| msgid ""
-#| "<span title='Do not Auto Validate Attendance if an Employee Works More Than "
-#| "this Amount of Duration'>{}</span>"
 msgid ""
 "Do not Auto Validate Attendance if an Employee Works More Than this Amount "
 "of Duration"
 msgstr ""
-"<span title='Не затверджувати автоматично відвідуваність, якщо співробітник "
-"працює довше цього часу'>{}</span>"
+"Не перевіряти відвідуваність автоматично, якщо співробітник працює довше "
+"цієї тривалості"
 
 msgid "Worked Hours(At Work) Auto Approve Till"
 msgstr "Автозатвердження відпрацьованих годин (На роботі) до"
@@ -1651,10 +1435,8 @@ msgstr "Неділя"
 msgid "Update Request"
 msgstr "Оновити запит"
 
-#, fuzzy
-#| msgid "Create Request"
 msgid "Created Request"
-msgstr "Створити запит"
+msgstr "Заявку створено"
 
 msgid "Attendance date"
 msgstr "Дата відвідування"
@@ -2089,6 +1871,8 @@ msgstr "Ви дійсно хочете видалити всі вибрані а
 msgid ""
 "Define the thresholds used to auto-validate attendance and approve overtime."
 msgstr ""
+"Визначте пороги для автоперевірки відвідуваності й затвердження "
+"понаднормових."
 
 msgid "Update Attendance condition "
 msgstr "Оновити умову відвідуваності "
@@ -2099,147 +1883,101 @@ msgstr "Створити умову відвідуваності "
 msgid "Home"
 msgstr "Головна"
 
-#, fuzzy
-#| msgid "Attendance Days"
 msgid "Attendance Dashboard"
-msgstr "Дні відвідуваності"
+msgstr "Дашборд відвідуваності"
 
-#, fuzzy
-#| msgid "dashboard"
 msgid "Customize dashboard"
-msgstr "панель керування"
+msgstr "налаштувати дашборд"
 
-#, fuzzy
-#| msgid "Contributions"
 msgid "Clock-in Distribution"
-msgstr "Внески"
+msgstr "Розподіл приходів"
 
 msgid "When employees clock in today"
-msgstr ""
+msgstr "Коли співробітники приходять сьогодні"
 
-#, fuzzy
-#| msgid "Export Attendance"
 msgid "Department Attendance"
-msgstr "Експортувати відвідуваність"
+msgstr "Відвідуваність за відділами"
 
-#, fuzzy
-#| msgid "Your attendance for the date "
 msgid "Today's attendance rate by department"
-msgstr "Вашу відвідуваність за дату "
+msgstr "Сьогоднішній рівень відвідуваності за відділами"
 
-#, fuzzy
-#| msgid "Attendance Validate"
 msgid "Attendance Calendar"
-msgstr "Перевірка відвідування"
+msgstr "Календар відвідуваності"
 
-#, fuzzy
-#| msgid "Attendance Date"
 msgid "Daily attendance rate"
-msgstr "Дата відвідуваності"
+msgstr "Щоденний рівень відвідуваності"
 
-#, fuzzy
-#| msgid "Attendance day"
 msgid "Attendance Trend"
-msgstr "День відвідування"
+msgstr "Тенденція відвідуваності"
 
 msgid "Headcount across the selected period"
-msgstr ""
+msgstr "Чисельність за вибраний період"
 
-#, fuzzy
-#| msgid "attendance-view"
 msgid "Attendance Overview"
-msgstr "attendance-view"
+msgstr "Огляд відвідуваності"
 
-#, fuzzy
-#| msgid "Track late arrivals and early departures of employees"
 msgid "On-time, late arrivals & early departures by department"
-msgstr "Відстежуйте пізні прибуття та ранні від’їзди співробітників"
+msgstr "Вчасно, запізнення та ранні виходи за відділами"
 
 msgid "Absenteeism Rate"
-msgstr ""
+msgstr "Рівень відсутності"
 
 msgid "Monthly trend — last 6 months"
-msgstr ""
+msgstr "Тенденція за місяцями — останні 6"
 
-#, fuzzy
-#| msgid "Name of the department"
 msgid "Today — by department"
-msgstr "Назва кафедри"
+msgstr "Сьогодні — за відділами"
 
-#, fuzzy
-#| msgid "Minimum Working Hours"
 msgid "Avg Working Hours"
-msgstr "Мінімальна кількість робочих годин"
+msgstr "Сер. робочі години"
 
-#, fuzzy
-#| msgid "There is no department at this moment."
 msgid "Per day by department — this month"
-msgstr "На цей момент немає жодного відділу."
+msgstr "За день по відділах — цього місяця"
 
-#, fuzzy
-#| msgid "Work Types"
 msgid "Work Type Distribution"
-msgstr "Типи роботи"
+msgstr "Розподіл типів роботи"
 
 msgid "Remote, on-site, hybrid, etc."
-msgstr ""
+msgstr "Віддалено, в офісі, гібрид тощо."
 
-#, fuzzy
-#| msgid "Same Department"
 msgid "Overtime by Department"
-msgstr "Той самий відділ"
+msgstr "Понаднормові за відділами"
 
-#, fuzzy
-#| msgid "This Month"
 msgid "This month"
 msgstr "Цього місяця"
 
-#, fuzzy
-#| msgid "Contributions"
 msgid "Hours Distribution"
-msgstr "Внески"
+msgstr "Розподіл годин"
 
 msgid "Worked vs pending hours by department"
-msgstr ""
+msgstr "Відпрацьовані та залишкові години за відділами"
 
-#, fuzzy
-#| msgid "Shift Information"
 msgid "Shift Distribution"
-msgstr "Інформація про зміну"
+msgstr "Розподіл змін"
 
-#, fuzzy
-#| msgid "Active Employees"
 msgid "Active employees by shift"
-msgstr "Активні працівники"
+msgstr "Активні співробітники за змінами"
 
-#, fuzzy
-#| msgid "Absent"
 msgid "Top Absentees"
-msgstr "Відсутній"
+msgstr "Найбільше відсутні"
 
 msgid "Reset to default"
-msgstr ""
+msgstr "Скинути до типового"
 
-#, fuzzy
-#| msgid "Overtime"
 msgid "Overview"
-msgstr "Понаднормові"
+msgstr "Огляд"
 
 msgid "Alerts"
-msgstr ""
+msgstr "Оповіщення"
 
-#, fuzzy
-#| msgid "Overtime"
 msgid "Hours & Overtime"
-msgstr "Понаднормові"
+msgstr "Години та понаднормові"
 
 msgid "As of"
-msgstr ""
+msgstr "Станом на"
 
-#, fuzzy
-#| msgid "Rating Visibility"
 msgid "Toggle visibility"
-msgstr "Видимість рейтингу"
+msgstr "Перемкнути видимість"
 
 msgid "ago"
 msgstr "Тег"
@@ -2253,148 +1991,102 @@ msgstr "рівень"
 msgid "On Time"
 msgstr "Вчасно"
 
-#, fuzzy
-#| msgid "employee"
 msgid "employees"
-msgstr "співробітник"
+msgstr "співробітники"
 
-#, fuzzy
-#| msgid "Early Out"
 msgid "early out"
 msgstr "Ранній вихід"
 
-#, fuzzy
-#| msgid "Early Out"
 msgid "No early outs"
-msgstr "Ранній вихід"
+msgstr "Немає ранніх виходів"
 
 msgid "Pending"
 msgstr "Очікується"
 
-#, fuzzy
-#| msgid "Pending"
 msgid "OT pending"
-msgstr "Очікується"
+msgstr "Понаднормові в очікуванні"
 
-#, fuzzy
-#| msgid "Not validated"
 msgid "To validate"
-msgstr "Не підтверджено"
+msgstr "До перевірки"
 
 msgid "Unable to load KPIs"
-msgstr ""
+msgstr "Не вдалося завантажити KPI"
 
 msgid "Weekly average headcount"
-msgstr ""
+msgstr "Середня чисельність за тиждень"
 
-#, fuzzy
-#| msgid "Penalty amount"
 msgid "Daily headcount"
-msgstr "Сума штрафу"
+msgstr "Щоденна чисельність"
 
 msgid "Today"
 msgstr "Сьогодні"
 
 msgid "Unable to load"
-msgstr ""
+msgstr "Не вдалося завантажити"
 
-#, fuzzy
-#| msgid "Attendance date from"
 msgid "Attendance rate by department"
-msgstr "Дата відвідуваності з"
+msgstr "Рівень відвідуваності за відділами"
 
 msgid "Rate"
 msgstr "Ставка"
 
-#, fuzzy
-#| msgid "department"
 msgid "By department"
-msgstr "відділ"
+msgstr "за відділом"
 
 msgid "No late/early records"
-msgstr ""
+msgstr "Немає записів запізнень/ранніх виходів"
 
-#, fuzzy
-#| msgid "One time date"
 msgid "No overtime data"
-msgstr "Одноразова дата"
+msgstr "Немає даних про понаднормові"
 
-#, fuzzy
-#| msgid "Total Hires"
 msgid "Total Hrs"
-msgstr "Всього найнято"
+msgstr "Всього годин"
 
-#, fuzzy
-#| msgid "Work Record"
 msgid "Worked"
-msgstr "Запис роботи"
+msgstr "Відпрацьовано"
 
-#, fuzzy
-#| msgid "Shift day"
 msgid "No shift data"
-msgstr "День зміни"
+msgstr "Немає даних про зміни"
 
-#, fuzzy
-#| msgid "Other employees"
 msgid "When employees clock in"
-msgstr "Інші працівники"
+msgstr "Коли співробітники приходять"
 
-#, fuzzy
-#| msgid "Clock in date"
 msgid "No clock-in data"
-msgstr "Дата приходу"
+msgstr "Немає даних про приходи"
 
-#, fuzzy
-#| msgid "employee"
 msgid "employee(s)"
-msgstr "співробітник"
+msgstr "співробітник(и)"
 
-#, fuzzy
-#| msgid "Attendance Date"
 msgid "Attendance Rate"
-msgstr "Дата відвідуваності"
+msgstr "Рівень відвідуваності"
 
-#, fuzzy
-#| msgid "Week"
 msgid "Week of"
-msgstr "Тиждень"
+msgstr "Тиждень від"
 
-#, fuzzy
-#| msgid "Present"
 msgid "present"
 msgstr "Присутній"
 
 msgid "absenteeism"
-msgstr ""
+msgstr "відсутність"
 
 msgid "Avg Hrs/Day"
-msgstr ""
+msgstr "Сер. год/день"
 
 msgid "8h target"
-msgstr ""
+msgstr "Ціль 8 год"
 
-#, fuzzy
-#| msgid "Next work type"
 msgid "No work type data"
-msgstr "Наступний тип роботи"
+msgstr "Немає даних про типи роботи"
 
-#, fuzzy
-#| msgid "No leave request this month"
 msgid "No absences this month"
-msgstr "Цього місяця немає заявок на відпустку"
+msgstr "Цього місяця відсутностей немає"
 
-#, fuzzy
-#| msgid "Half Day Present"
 msgid "days present"
-msgstr "Присутній половину дня"
+msgstr "днів присутності"
 
-#, fuzzy
-#| msgid "No records available."
 msgid "No attendance records available"
-msgstr "Немає доступних записів."
+msgstr "Немає записів відвідуваності"
 
-#, fuzzy
-#| msgid "Activities"
 msgid " Activities"
 msgstr "Активність"
 
@@ -2432,13 +2124,13 @@ msgid "No employees are currently taking a break."
 msgstr "Наразі немає співробітників на перерві."
 
 msgid "checkmark outline"
-msgstr ""
+msgstr "checkmark outline"
 
 msgid "No overtime records pending validation."
 msgstr "Немає записів понаднормових на підтвердження."
 
 msgid "caret back outline"
-msgstr ""
+msgstr "caret back outline"
 
 msgid "No pending attendance to validate."
 msgstr "Немає відвідуваності, що очікує підтвердження."
@@ -2446,10 +2138,8 @@ msgstr "Немає відвідуваності, що очікує підтве�
 msgid "Assign Shifts"
 msgstr "Призначити зміни"
 
-#, fuzzy
-#| msgid "validation condition deleted."
 msgid "Validation Condition"
-msgstr "Умову перевірки видалено."
+msgstr "Умова перевірки"
 
 msgid "Shifts"
 msgstr "Зміни"
@@ -2458,6 +2148,8 @@ msgid ""
 "Set the buffer time allowed before check-in or after check-out is marked "
 "late or early."
 msgstr ""
+"Задайте допустимий буфер до приходу або після виходу, щоб позначити "
+"запізнення чи ранній вихід."
 
 msgid "Are you sure you want to delete this IP ?"
 msgstr "Ви впевнені, що хочете видалити цю IP-адресу?"
@@ -2496,7 +2188,7 @@ msgid "No penalties found."
 msgstr "Штрафів не знайдено."
 
 msgid "information circle outline"
-msgstr ""
+msgstr "information circle outline"
 
 msgid "Tracking Enable"
 msgstr "Відстеження увімкнено"
@@ -2538,12 +2230,12 @@ msgid ""
 "Configure attendance tracking, check-in/out, biometric and IP restriction "
 "rules."
 msgstr ""
+"Налаштуйте відстеження відвідуваності, приходи/виходи, біометрію та "
+"обмеження IP."
 
 msgid "Check In/Check Out"
 msgstr "Реєстрація приходу/виходу"
 
-#, fuzzy
-#| msgid "Enable Check In / Check Out"
 msgid "Enable Check In/Check Out"
 msgstr "Увімкнути заїзд/виїзд"
 
@@ -2582,6 +2274,8 @@ msgid ""
 "Once you enable this option, a new submenu called Biometric Devices will be "
 "added under the Attendance menu."
 msgstr ""
+"Увімкнувши цю опцію, під меню «Відвідування» з'явиться новий підпункт "
+"«Біометричні пристрої»."
 
 msgid "Activated"
 msgstr "Активовано"
@@ -2589,23 +2283,21 @@ msgstr "Активовано"
 msgid "Activate"
 msgstr "Активувати"
 
-#, fuzzy
-#| msgid "Face Detection"
 msgid "Enable Face Detection"
-msgstr "Розпізнавання обличчя"
+msgstr "Увімкнути розпізнавання обличчя"
 
-#, fuzzy
-#| msgid "Allow employees to mark attendance using face detection"
 msgid ""
 "By enabling this, employees can mark their attendance using face detection."
 msgstr ""
-"Дозвольте співробітникам позначати присутність за допомогою розпізнавання "
-"обличчя"
+"Увімкнувши це, співробітники зможуть відмічати відвідуваність розпізнаванням"
+" обличчя."
 
 msgid ""
 "Configure the location and radius within which employees are allowed to mark"
 " their attendance."
 msgstr ""
+"Налаштуйте локацію й радіус, у межах якого співробітники можуть відмічати "
+"відвідуваність."
 
 msgid "Download"
 msgstr "Завантажити"
@@ -2616,10 +2308,8 @@ msgstr "Відпустка"
 msgid "On leave, But attendance exist"
 msgstr "У відпустці, але відвідуваність існує"
 
-#, fuzzy
-#| msgid "Work Records"
 msgid "Work Record Status"
-msgstr "Записи роботи"
+msgstr "Статус запису роботи"
 
 msgid "Date:"
 msgstr "Дата:"
@@ -2655,7 +2345,7 @@ msgid "Add / View Comment"
 msgstr "Додати / Переглянути коментар"
 
 msgid "newspaper outline"
-msgstr ""
+msgstr "newspaper outline"
 
 msgid "Cancel / Reject"
 msgstr "Скасувати / Відхилити"
@@ -2666,55 +2356,35 @@ msgstr "Ви впевнені, що хочете скасувати запит?"
 msgid "Re-validate Request"
 msgstr "Повторно перевірити запит"
 
-#, fuzzy
-#| msgid "At Work Less Than or Equal"
 msgid "At Work Lesser or Equal"
 msgstr "На роботі менше або дорівнює"
 
-#, fuzzy
-#| msgid "Pending Hour Less Than or Equal"
 msgid "Pending Hour Lesser or Equal"
 msgstr "Годин в очікуванні менше або дорівнює"
 
-#, fuzzy
-#| msgid "OT Less Than or Equal"
 msgid "OT Lesser or Equal"
-msgstr "Понаднормових менше або дорівнює"
+msgstr "Понаднормові менше або дорівнює"
 
-#, fuzzy
-#| msgid "Bulk-Requests"
 msgid "Bulk Request"
-msgstr "Масові запити"
+msgstr "Масова заявка"
 
-#, fuzzy
-#| msgid "Do you want to approve this request?"
 msgid "Do you want to approve this overtime?"
-msgstr "Затвердити цей запит?"
+msgstr "Ви бажаєте затвердити ці понаднормові?"
 
-#, fuzzy
-#| msgid "Approve Overtime"
 msgid "Approve Overtime (OT < min.OT)"
-msgstr "Затвердити понаднормові"
+msgstr "Затвердити понаднормові (OT < min.OT)"
 
-#, fuzzy
-#| msgid "Do you want to delete this attachment?"
 msgid "Do you want to validate this attendance?"
-msgstr "Ви бажаєте видалити цей вкладений файл?"
+msgstr "Ви бажаєте перевірити це відвідування?"
 
-#, fuzzy
-#| msgid "Hours to Validate"
 msgid "Hours to validate"
 msgstr "Години для підтвердження"
 
-#, fuzzy
-#| msgid "OT Approved?"
 msgid "OT to Approve"
-msgstr "Понаднормові затверджено?"
+msgstr "Понаднормові до затвердження"
 
-#, fuzzy
-#| msgid "Penalties"
 msgid "No Penalties"
-msgstr "Штрафи"
+msgstr "Немає штрафів"
 
 msgid "Assign shift"
 msgstr "Призначити зміну"
@@ -2844,22 +2514,20 @@ msgid "Overtime approved"
 msgstr "Понаднормові затверджено"
 
 msgid "Check-In Restricted: Your current network is not authorized "
-msgstr ""
+msgstr "Прихід обмежено: ваша мережа не авторизована "
 
 msgid ""
 "Check-In Unavailable: Your employee profile or work information is "
 "incomplete."
-msgstr ""
+msgstr "Прихід недоступний: ваш профіль або робоча інформація неповні."
 
-#, fuzzy
-#| msgid "Check in/Check out feature is not enabled."
 msgid ""
 "The attendance check-in/check-out feature has not been enabled for your "
 "company."
-msgstr "Функція відмітки приходу/виходу не увімкнена."
+msgstr "Функція приходу/виходу не увімкнена для вашої компанії."
 
 msgid "Check-Out Restricted: Your current network is not authorized"
-msgstr ""
+msgstr "Вихід обмежено: ваша мережа не авторизована"
 
 msgid "No validated Overtimes were found"
 msgstr "Перевірених понаднормових не знайдено"
@@ -2888,10 +2556,8 @@ msgstr "Щось пішло не так."
 msgid "This {} is already in use for {}."
 msgstr "Це {} вже використовується для {}."
 
-#, fuzzy
-#| msgid "No Attachment found matching the query."
 msgid "No Attendance found matching the query."
-msgstr "Вкладень, що відповідають запиту, не знайдено."
+msgstr "Записів відвідуваності за цим запитом не знайдено."
 
 msgid "Attendance request has been approved"
 msgstr "Запит на відвідуваність затверджено"
@@ -2964,10 +2630,8 @@ msgstr "Запис про запізнення/ранній вихід не іс
 msgid "Attendance not found."
 msgstr "Відвідуваність не знайдено."
 
-#, fuzzy
-#| msgid "Late-in early-out deleted"
 msgid "{} Late-in early-out deleted."
-msgstr "Запис про запізнення/ранній вихід видалено"
+msgstr "{} записів запізнень/ранніх виходів видалено."
 
 msgid "validation condition Does not exists.."
 msgstr "Умова перевірки не існує.."
@@ -2984,29 +2648,22 @@ msgstr "Очікує запит на оновлення відвідуванос
 msgid "{} Attendances validated."
 msgstr "{} відвідуваностей перевірено."
 
-#, fuzzy
-#| msgid "You cannot delete this attendance"
 msgid "You cannot validate your own attendance."
-msgstr "Ви не можете видалити цю відвідуваність"
+msgstr "Ви не можете перевірити власне відвідування."
 
 #, python-format
 msgid "%(employee)s %(date)s Attendance validated."
 msgstr "%(employee)s %(date)s Відвідування підтверджено."
 
-#, fuzzy
-#| msgid "You cannot add more conditions."
 msgid "You cannot approve your own overtime."
-msgstr "Ви не можете додати більше умов."
+msgstr "Ви не можете затвердити власні понаднормові."
 
-#, fuzzy, python-format
-#| msgid "%(employee)s's %(objective)s deleted"
+#, python-format
 msgid "%(employee)s's %(date)s overtime approved"
-msgstr "%(objective)s співробітника %(employee)s видалено"
+msgstr "Понаднормові %(employee)s за %(date)s затверджено"
 
-#, fuzzy
-#| msgid "Overtime approved"
 msgid " {} Overtime approved"
-msgstr "Понаднормові затверджено"
+msgstr " {} понаднормових затверджено"
 
 msgid "Grace time added to shifts successfully."
 msgstr "Пільговий час успішно додано до змін."
@@ -3044,10 +2701,8 @@ msgstr "Щось пішло не так ."
 msgid "Comment added successfully!"
 msgstr "Коментар успішно додано!"
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Comment found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Коментарів за цим запитом не знайдено."
 
 msgid "Comment deleted successfully!"
 msgstr "Коментар успішно видалено!"
@@ -3074,43 +2729,29 @@ msgstr "Введіть дійсну адресу IPv4 або IPv6."
 msgid "IP addresses already exist: %(ips)s"
 msgstr "IP-адреси вже існують: %(ips)s"
 
-#, fuzzy
-#| msgid "Python code saved successfully!"
 msgid "IP addresses saved successfully"
-msgstr "Код Python успішно збережено!"
+msgstr "IP-адреси успішно збережено"
 
 msgid "All provided IP addresses are already in the allowed list."
-msgstr ""
+msgstr "Усі надані IP-адреси вже є у списку дозволених."
 
-#, fuzzy
-#| msgid "Interviewer removed succesfully."
 msgid "IP address removed successfully"
-msgstr "Інтерв'юера успішно видалено."
+msgstr "IP-адресу успішно вилучено"
 
-#, fuzzy
-#| msgid "Invalid time"
 msgid "Invalid id"
-msgstr "Невірний час"
+msgstr "Невірний ID"
 
-#, fuzzy
-#| msgid "No Files found."
 msgid "No allowed IPs found."
-msgstr "Файли не знайдено."
+msgstr "Дозволених IP не знайдено."
 
-#, fuzzy
-#| msgid "IP addresses already exist: %(ips)s"
 msgid "IP address already exists."
-msgstr "IP-адреси вже існують: %(ips)s"
+msgstr "IP-адреса вже існує."
 
-#, fuzzy
-#| msgid "Task updated successfully"
 msgid "IP address updated successfully"
-msgstr "Завдання успішно оновлено"
+msgstr "IP-адресу успішно оновлено"
 
-#, fuzzy
-#| msgid "Invalid list of IDs provided."
 msgid "Invalid ID provided."
-msgstr "Надано недійсний список ID."
+msgstr "Надано недійсний ID."
 
 msgid "Your department was mentioned in an announcement."
 msgstr "Ваш відділ згадано в оголошенні."
@@ -3136,20 +2777,14 @@ msgstr "Файл успішно видалено."
 msgid "You commented a post."
 msgstr "Ви прокоментували публікацію."
 
-#, fuzzy
-#| msgid "Create Announcement"
 msgid "Create Announcements."
-msgstr "Створити оголошення"
+msgstr "Створити оголошення."
 
-#, fuzzy
-#| msgid "Announcement"
 msgid "Edit Announcement."
-msgstr "Оголошення"
+msgstr "Редагувати оголошення."
 
-#, fuzzy
-#| msgid "Announcement created successfully."
 msgid "Announcement created successfully to all employees in "
-msgstr "Оголошення успішно створено."
+msgstr "Оголошення успішно створено для всіх співробітників у "
 
 #, python-format
 msgid "File type %(ext)s is not allowed for security reasons."
@@ -3173,25 +2808,17 @@ msgstr "Індекс"
 msgid "Companies"
 msgstr "Компанії"
 
-#, fuzzy
-#| msgid "Create Company Leaves"
 msgid "Create Company"
-msgstr "Створити відпустки компанії"
+msgstr "Створити компанію"
 
-#, fuzzy
-#| msgid "Update Company Leaves"
 msgid "Update Company"
-msgstr "Оновити відпустки компанії"
+msgstr "Оновити компанію"
 
-#, fuzzy
-#| msgid "{} Holidays have been successfully deleted."
 msgid "Company have been successfully updated."
-msgstr "{} свят успішно видалено."
+msgstr "Компанію успішно оновлено."
 
-#, fuzzy
-#| msgid "{} Holidays have been successfully deleted."
 msgid "Company have been successfully created."
-msgstr "{} свят успішно видалено."
+msgstr "Компанію успішно створено."
 
 msgid "Based On Week"
 msgstr "На основі тижня"
@@ -3208,13 +2835,9 @@ msgstr "Створити відпустки компанії"
 msgid "Update Company Leaves"
 msgstr "Оновити відпустки компанії"
 
-#, fuzzy
-#| msgid "Company leave updated successfully.."
 msgid "Company Leave Updated Successfully"
 msgstr "Відпустку компанії успішно оновлено.."
 
-#, fuzzy
-#| msgid "New company leave created successfully.."
 msgid "New Company Leave Created Successfully"
 msgstr "Нову відпустку компанії успішно створено.."
 
@@ -3227,15 +2850,11 @@ msgstr "Запитувана зміна"
 msgid "Progress"
 msgstr "Прогрес"
 
-#, fuzzy
-#| msgid "Work Information"
 msgid "Update Work Information"
-msgstr "Робоча інформація"
+msgstr "Оновити робочу інформацію"
 
-#, fuzzy
-#| msgid "Work Information"
 msgid "Work Information Updated"
-msgstr "Робоча інформація"
+msgstr "Робочу інформацію оновлено"
 
 msgid "Viewed By"
 msgstr "Переглянуто"
@@ -3246,18 +2865,12 @@ msgstr "Керівник"
 msgid "Departments"
 msgstr "Відділи"
 
-#, fuzzy
-#| msgid "Same Department"
 msgid "Create Department"
-msgstr "Той самий відділ"
+msgstr "Створити відділ"
 
-#, fuzzy
-#| msgid "Same Department"
 msgid "Update Department"
-msgstr "Той самий відділ"
+msgstr "Оновити відділ"
 
-#, fuzzy
-#| msgid "Department updated."
 msgid "Department updated"
 msgstr "Відділ оновлено."
 
@@ -3276,20 +2889,14 @@ msgstr "Повна зайнятість"
 msgid "Shift Schedule"
 msgstr "Графік змін"
 
-#, fuzzy
-#| msgid "Employee Shift Schedule"
 msgid "Create Employee Shift Schedule"
-msgstr "Графік зміни співробітника"
+msgstr "Створити розклад змін співробітника"
 
-#, fuzzy
-#| msgid "Employee Shift Schedule"
 msgid "Update Employee Shift Schedule"
-msgstr "Графік зміни співробітника"
+msgstr "Оновити розклад змін співробітника"
 
-#, fuzzy
-#| msgid "Shift schedule created."
 msgid "Shift schedule Updated!."
-msgstr "Графік зміни створено."
+msgstr "Розклад змін оновлено!"
 
 msgid "Employee Shift Schedule has been created successfully!"
 msgstr "Графік зміни співробітника успішно створено!"
@@ -3303,38 +2910,26 @@ msgstr "Час завершення"
 msgid "Minimum Working Hours"
 msgstr "Мінімальна кількість робочих годин"
 
-#, fuzzy
-#| msgid "Check Out"
 msgid "Auto Check Out"
-msgstr "Вихід"
+msgstr "Автоматичний вихід"
 
-#, fuzzy
-#| msgid "Shift request not found."
 msgid "Shift schedule not found."
-msgstr "Запит на зміну не знайдено."
+msgstr "Розклад змін не знайдено."
 
 msgid "Automatic Check Out Time"
 msgstr "Час автоматичного виходу"
 
-#, fuzzy
-#| msgid "Create Employee Tag"
 msgid "Create Employee Type"
-msgstr "Створити тег працівника"
+msgstr "Створити тип зайнятості"
 
-#, fuzzy
-#| msgid "Update Employee Tag"
 msgid "Update Employee Type"
-msgstr "Оновити тег працівника"
+msgstr "Оновити тип зайнятості"
 
-#, fuzzy
-#| msgid "The comment updated successfully."
 msgid "The employee type updated successfully."
-msgstr "Коментар успішно оновлено."
+msgstr "Тип зайнятості успішно оновлено."
 
-#, fuzzy
-#| msgid "Employee objective created successfully"
 msgid "The employee type created successfully."
-msgstr "Ціль співробітника успішно створено"
+msgstr "Тип зайнятості успішно створено."
 
 msgid "Holiday Name"
 msgstr "Назва свята"
@@ -3351,25 +2946,17 @@ msgstr "Створити свято"
 msgid "Update Holiday"
 msgstr "Оновити свято"
 
-#, fuzzy
-#| msgid "Holidays updated successfully.."
 msgid "Holiday Updated Successfully"
-msgstr "Свята успішно оновлено.."
+msgstr "Свято успішно оновлено"
 
-#, fuzzy
-#| msgid "New holiday created successfully.."
 msgid "New Holiday Created Successfully"
 msgstr "Нове свято успішно створено.."
 
-#, fuzzy
-#| msgid "Same Job Position"
 msgid "Create Job Position"
-msgstr "Та сама посада"
+msgstr "Створити посаду"
 
-#, fuzzy
-#| msgid "Same Job Position"
 msgid "Update Job Position"
-msgstr "Та сама посада"
+msgstr "Оновити посаду"
 
 msgid "Job position updated."
 msgstr "Посаду оновлено."
@@ -3377,20 +2964,14 @@ msgstr "Посаду оновлено."
 msgid "Job Roles"
 msgstr "Ролі посад"
 
-#, fuzzy
-#| msgid "Job Role"
 msgid "Create Job Role"
-msgstr "Роль"
+msgstr "Створити роль"
 
-#, fuzzy
-#| msgid "Job Role"
 msgid "Update Job Role"
-msgstr "Роль"
+msgstr "Оновити роль"
 
-#, fuzzy
-#| msgid "Job role has been created successfully!"
 msgid "Job role has been updated successfully!"
-msgstr "Робочу роль успішно створено!"
+msgstr "Роль успішно оновлено!"
 
 msgid "Subject"
 msgstr "Тема"
@@ -3419,30 +3000,20 @@ msgstr "Поштовий сервер успішно створено."
 msgid "Add Template"
 msgstr "Додати шаблон"
 
-#, fuzzy
-#| msgid "Add Template"
 msgid "Update Template"
-msgstr "Додати шаблон"
+msgstr "Оновити шаблон"
 
-#, fuzzy
-#| msgid "Template updated"
 msgid "Template Updated"
 msgstr "Шаблон оновлено"
 
-#, fuzzy
-#| msgid "Template updated"
 msgid "Template created"
-msgstr "Шаблон оновлено"
+msgstr "Шаблон створено"
 
-#, fuzzy
-#| msgid "Duplicate Survey Template"
 msgid "Duplicate Template"
-msgstr "Дублювати шаблон опитування"
+msgstr "Дублювати шаблон"
 
-#, fuzzy
-#| msgid "Template deleted"
 msgid "Template Added"
-msgstr "Шаблон видалено"
+msgstr "Шаблон додано"
 
 msgid "Mail Templates"
 msgstr "Шаблони листів"
@@ -3459,73 +3030,56 @@ msgstr "Значення умови"
 msgid "Approval Managers"
 msgstr "Керівники, що затверджують"
 
-#, fuzzy
-#| msgid "Multiple Approvals"
 msgid "Multiple Approval Rules"
-msgstr "Множинні затвердження"
+msgstr "Правила багатоетапного погодження"
 
-#, fuzzy
-#| msgid "Multiple Approval Condition"
 msgid "Create Multiple Approval Condition"
-msgstr "Умова множинного затвердження"
+msgstr "Створити умову багатоетапного погодження"
 
-#, fuzzy
-#| msgid "Multiple approval condition created successfully"
 msgid "Multiple approval conditon Created Successfully"
-msgstr "Умову багаторівневого затвердження успішно створено"
+msgstr "Умову багатоетапного погодження успішно створено"
 
-#, fuzzy
-#| msgid "Multiple Approval Condition"
 msgid "Update Multiple Approval Condition"
-msgstr "Умова множинного затвердження"
+msgstr "Оновити умову багатоетапного погодження"
 
 msgid "Approval Manager"
 msgstr "Керівник затвердження"
 
-#, fuzzy
-#| msgid "Multiple approval condition updated successfully"
 msgid "Multiple approval conditon updated Successfully"
-msgstr "Умову багаторівневого затвердження успішно оновлено"
+msgstr "Умову багатоетапного погодження успішно оновлено"
 
 msgid "Roster Planner"
-msgstr ""
+msgstr "Планувальник графіка"
 
-#, fuzzy
-#| msgid "Import Records"
 msgid "Import Roster"
-msgstr "Імпортувати записи"
+msgstr "Імпортувати графік"
 
-#, fuzzy
-#| msgid "Is Published"
 msgid "Publish Roster"
-msgstr "Опубліковано"
+msgstr "Опублікувати графік"
 
-#, fuzzy
-#| msgid "Departments"
 msgid "All Departments"
-msgstr "Відділи"
+msgstr "Усі відділи"
 
 #, python-format
 msgid "Roster published for %(dept)s (%(range)s)."
-msgstr ""
+msgstr "Графік опубліковано для %(dept)s (%(range)s)."
 
 #, python-format
 msgid "Roster published for %(count)s employee(s)."
-msgstr ""
+msgstr "Графік опубліковано для %(count)s співробітник(ів)."
 
 msgid "No file uploaded."
 msgstr "Файл не завантажено."
 
-#, fuzzy
-#| msgid "Please upload a valid XLSX file."
 msgid "Please upload a valid .xlsx file."
 msgstr "Будь ласка, завантажте дійсний файл XLSX."
 
 msgid "Could not read the file. Please upload the unmodified template."
-msgstr ""
+msgstr "Не вдалося прочитати файл. Завантажте незмінений шаблон."
 
 msgid "Could not read date headers. Please use the downloaded template."
 msgstr ""
+"Не вдалося прочитати заголовки дат. Скористайтеся завантаженим шаблоном."
 
 msgid "Shift 1"
 msgstr "Зміна 1"
@@ -3539,23 +3093,15 @@ msgstr "Додаткові зміни"
 msgid "Rotating Shift"
 msgstr "Змінна зміна"
 
-#, fuzzy
-#| msgid "Import Rotating Shift"
 msgid "Create Rotating Shift"
-msgstr "Імпортувати позмінну ротацію"
+msgstr "Створити змінну зміну"
 
-#, fuzzy
-#| msgid "Rotating shift created."
 msgid "Rotating Shift Created"
 msgstr "Змінну зміну створено."
 
-#, fuzzy
-#| msgid "Import Rotating Shift"
 msgid "Update Rotating Shift Type"
-msgstr "Імпортувати позмінну ротацію"
+msgstr "Оновити тип змінної зміни"
 
-#, fuzzy
-#| msgid "Rotating shift updated."
 msgid "Rotating Shift Updated"
 msgstr "Змінну зміну оновлено."
 
@@ -3595,15 +3141,11 @@ msgstr "Призначення змінної зміни"
 msgid "Rotating Shift Assign Update"
 msgstr "Оновлення призначення позмінної ротації"
 
-#, fuzzy
-#| msgid "Rotating Shift Assign Update"
 msgid "Rotating Shift Assign Updated Successfully"
-msgstr "Оновлення призначення позмінної ротації"
+msgstr "Призначення змінної зміни успішно оновлено"
 
-#, fuzzy
-#| msgid "Rotating Shift Assign Update"
 msgid "Rotating Shift Assign Created Successfully"
-msgstr "Оновлення призначення позмінної ротації"
+msgstr "Призначення змінної зміни успішно створено"
 
 msgid "Rotating Work Type"
 msgstr "Змінний тип роботи"
@@ -3620,20 +3162,14 @@ msgstr "Наступний тип роботи"
 msgid "Rotating Work Type Assign"
 msgstr "Призначення змінного типу роботи"
 
-#, fuzzy
-#| msgid "Work Information Updated Successfully"
 msgid "Rotating Work Assign Updated Successfully"
-msgstr "Робочу інформацію успішно оновлено"
+msgstr "Призначення змінного типу роботи успішно оновлено"
 
-#, fuzzy
-#| msgid "Rotating Work Type Assign"
 msgid "Rotating Work Assigned"
-msgstr "Призначення змінного типу роботи"
+msgstr "Змінний тип роботи призначено"
 
-#, fuzzy
-#| msgid "Rotating Work Type Assign"
 msgid "Rotating Work Assign Created"
-msgstr "Призначення змінного типу роботи"
+msgstr "Призначення змінного типу роботи створено"
 
 msgid "Work Type 1"
 msgstr "Тип роботи 1"
@@ -3641,33 +3177,21 @@ msgstr "Тип роботи 1"
 msgid "Work Type 2"
 msgstr "Тип роботи 2"
 
-#, fuzzy
-#| msgid "Rotating Work Types"
 msgid "Additional Work Types"
-msgstr "Змінні типи роботи"
+msgstr "Додаткові типи роботи"
 
-#, fuzzy
-#| msgid "Rotating Work Type"
 msgid "Create Rotating Work Type"
-msgstr "Змінний тип роботи"
+msgstr "Створити змінний тип роботи"
 
-#, fuzzy
-#| msgid "Rotating work type created."
 msgid "Rotating Work Type Created"
 msgstr "Змінний тип роботи створено."
 
-#, fuzzy
-#| msgid "Rotating Work Type"
 msgid "Update Rotating Work Type"
-msgstr "Змінний тип роботи"
+msgstr "Оновити змінний тип роботи"
 
-#, fuzzy
-#| msgid "Update Action Type"
 msgid "Update Work Type"
-msgstr "Оновити тип дії"
+msgstr "Оновити тип роботи"
 
-#, fuzzy
-#| msgid "Rotating work type updated."
 msgid "Rotating Work Type Updated"
 msgstr "Змінний тип роботи оновлено."
 
@@ -3704,33 +3228,23 @@ msgstr "Попередня зміна"
 msgid "Is permenent shift"
 msgstr "Постійна зміна"
 
-#, fuzzy
-#| msgid "Shift updated"
 msgid "Shift Created"
-msgstr "Зміну оновлено"
+msgstr "Зміну створено"
 
-#, fuzzy
-#| msgid "Update Shift Request"
 msgid "Update Shift"
-msgstr "Оновити запит на зміну"
+msgstr "Оновити зміну"
 
-#, fuzzy
-#| msgid "Shift updated"
 msgid "Shift Updated"
 msgstr "Зміну оновлено"
 
 msgid "Create Shift Request"
 msgstr "Створити запит на зміну"
 
-#, fuzzy
-#| msgid "Request Updated Successfully"
 msgid "Shift request updated Successfully"
-msgstr "Запит успішно оновлено"
+msgstr "Заявку на зміну успішно оновлено"
 
-#, fuzzy
-#| msgid "Request Updated Successfully"
 msgid "Shift request added Successfully"
-msgstr "Запит успішно оновлено"
+msgstr "Заявку на зміну успішно додано"
 
 msgid "Shift Request"
 msgstr "Запит на зміну"
@@ -3738,65 +3252,45 @@ msgstr "Запит на зміну"
 msgid "Work type request"
 msgstr "Запит на тип роботи"
 
-#, fuzzy
-#| msgid "Work Type Request"
 msgid "Add Work Type Request"
-msgstr "Запит на тип роботи"
+msgstr "Додати заявку на тип роботи"
 
 msgid "Rotating work type"
 msgstr "Змінний тип роботи"
 
-#, fuzzy
-#| msgid "Rotating Work Type"
 msgid "Add Rotating Work"
-msgstr "Змінний тип роботи"
+msgstr "Додати змінний тип роботи"
 
 msgid "Shift request"
 msgstr "Запит на зміну"
 
-#, fuzzy
-#| msgid "Shift Request"
 msgid "Add Shift Request"
-msgstr "Запит на зміну"
+msgstr "Додати заявку на зміну"
 
-#, fuzzy
-#| msgid "Rotating Shift"
 msgid "Add Rotating Shift"
-msgstr "Змінна зміна"
+msgstr "Додати змінну зміну"
 
-#, fuzzy
-#| msgid "Previous/Current Work Type"
 msgid "Previous/current Work Type"
 msgstr "Попередній/поточний тип роботи"
 
 msgid "Work Type Requests"
 msgstr "Запити на тип роботи"
 
-#, fuzzy
-#| msgid "Current Work Type"
 msgid "current Work Type"
 msgstr "Поточний тип роботи"
 
 msgid "Previous Work Type"
 msgstr "Попередній тип роботи"
 
-#, fuzzy
-#| msgid "Is permenent work type"
 msgid "Is Permanent Work Type"
 msgstr "Постійний тип роботи"
 
-#, fuzzy
-#| msgid "Current Work Type"
 msgid "Create Work Type"
-msgstr "Поточний тип роботи"
+msgstr "Створити тип роботи"
 
-#, fuzzy
-#| msgid "New leave type Created.."
 msgid "New Work Type Created"
-msgstr "Новий тип відпустки створено.."
+msgstr "Новий тип роботи створено"
 
-#, fuzzy
-#| msgid "Work type updated."
 msgid "Work Type Updated"
 msgstr "Тип роботи оновлено."
 
@@ -3806,46 +3300,38 @@ msgstr "Запит на тип роботи"
 msgid "Request Updated Successfully"
 msgstr "Запит успішно оновлено"
 
-#, fuzzy
-#| msgid "Work type request deleted."
 msgid "Work type Request Created"
-msgstr "Запит на зміну типу роботи видалено."
+msgstr "Заявку на тип роботи створено"
 
-#, fuzzy
-#| msgid "You dont have access to the feature"
 msgid "You do not have access to that company."
-msgstr "У вас немає доступу до цієї функції"
+msgstr "У вас немає доступу до цієї компанії."
 
-#, fuzzy
-#| msgid "You do not have permission to view the documents."
 msgid "You do not have permission to switch the company."
-msgstr "У вас немає дозволу на перегляд документів."
+msgstr "У вас немає дозволу перемикати компанію."
 
 msgid "Profile Edit Access"
 msgstr "Доступ до редагування профілю"
 
 msgid "Add your company profile — name, logo and timezone."
-msgstr ""
+msgstr "Додайте профіль компанії — назву, логотип і часовий пояс."
 
 msgid "Create the departments your employees will belong to."
-msgstr ""
+msgstr "Створіть відділи, до яких належатимуть співробітники."
 
 msgid "Job Positions"
 msgstr "Посади"
 
-#, fuzzy
-#| msgid "Name of the department"
 msgid "Define named roles within each department."
-msgstr "Назва кафедри"
+msgstr "Визначте назви ролей у кожному відділі."
 
 msgid "Define working schedules — Morning, Evening, Night."
-msgstr ""
+msgstr "Визначте робочі розклади — ранок, вечір, ніч."
 
 msgid "Set day-wise timings for each shift."
-msgstr ""
+msgstr "Задайте час для кожної зміни по днях."
 
 msgid "Set engagement types — Full Time, Part Time, Contract."
-msgstr ""
+msgstr "Визначте типи зайнятості — повна, часткова, контракт."
 
 msgid "Mail Server"
 msgstr "Поштовий сервер"
@@ -3875,45 +3361,42 @@ msgstr "Вихідний"
 msgid "---Choose {label}---"
 msgstr "---Виберіть {label}---"
 
-#, fuzzy
-#| msgid "Group By"
 msgid "Group name"
-msgstr "Групувати за"
+msgstr "Назва групи"
 
 msgid "Give this group a clear name, e.g. HR Managers or Finance Team."
-msgstr ""
+msgstr "Дайте групі чітку назву, напр. HR-менеджери або Фінансова команда."
 
-#, fuzzy
-#| msgid "HR Manager"
 msgid "e.g. HR Managers"
-msgstr "Менеджер з персоналу"
+msgstr "напр. HR-менеджери"
 
 msgid "Search and select who should belong to this group."
-msgstr ""
+msgstr "Знайдіть і виберіть, хто має належати до цієї групи."
 
-#, fuzzy
-#| msgid "Invalid Recruitment ID"
 msgid "Invalid group ID."
-msgstr "Недійсний ID набору"
+msgstr "Недійсний ID групи."
 
 msgid ""
 "Members get this group's permissions only in the selected companies. Leave "
 "empty for all companies you can manage."
 msgstr ""
+"Учасники отримують дозволи цієї групи лише у вибраних компаніях. Порожнє — "
+"для всіх компаній, якими ви керуєте."
 
-#, fuzzy
-#| msgid "Search Employee"
 msgid "Search employees..."
-msgstr "Пошук співробітника"
+msgstr "Пошук співробітників..."
 
 msgid ""
 "Members get this group's permissions only in the selected companies. You can"
 " only assign companies you already have access to. Leave empty for all of "
 "those companies."
 msgstr ""
+"Учасники отримують дозволи цієї групи лише у вибраних компаніях. Ви можете "
+"призначати лише компанії, до яких уже маєте доступ. Порожнє — для всіх таких"
+" компаній."
 
 msgid "You cannot assign this group for companies you do not manage."
-msgstr ""
+msgstr "Ви не можете призначити цю групу компаніям, якими не керуєте."
 
 msgid "File size should be less than 5MB."
 msgstr "Розмір файлу має бути менше 5 Мб."
@@ -3925,18 +3408,17 @@ msgid ""
 "Assigning a manager here also reflects in the Helpdesk department managers "
 "section."
 msgstr ""
+"Призначення керівника тут також відображається в розділі керівників відділів"
+" служби підтримки."
 
-#, fuzzy, python-format
-#| msgid "This employee is not eligible for any deductions."
+#, python-format
 msgid "This employee is not from %(department)s."
-msgstr "Цей працівник не має права на жодні утримання."
+msgstr "Цей співробітник не з відділу %(department)s."
 
 #, python-format
 msgid "Job position already exists under %(dep)s"
 msgstr "Вакансія вже існує під %(dep)s"
 
-#, fuzzy
-#| msgid "Job Position has been created successfully!"
 msgid "Job position has been created successfully!"
 msgstr "Посаду успішно створено!"
 
@@ -3953,10 +3435,8 @@ msgstr "Роль вже існує під %(position)s"
 msgid "---Choose Work Type---"
 msgstr "---Виберіть тип роботи---"
 
-#, fuzzy
-#| msgid "Rotate after "
 msgid "Rotate after day"
-msgstr "Змінювати через "
+msgstr "Змінювати після дня"
 
 msgid "Start date"
 msgstr "Дата початку"
@@ -3964,8 +3444,6 @@ msgstr "Дата початку"
 msgid "Is Active"
 msgstr "Активний"
 
-#, fuzzy
-#| msgid "Rotate Every Weekend"
 msgid "Rotate every weekend"
 msgstr "Змінювати щовихідних"
 
@@ -4058,10 +3536,8 @@ msgstr "Пароль успішно змінено"
 msgid "Password must be same."
 msgstr "Паролі повинні збігатися."
 
-#, fuzzy
-#| msgid "Test email"
 msgid "To email"
-msgstr "Тестовий лист"
+msgstr "На email"
 
 msgid "Equal (==)"
 msgstr "Дорівнює (==)"
@@ -4091,6 +3567,8 @@ msgid ""
 "If no employee, department or job position is selected, the announcement "
 "will be visible to all employees in the selected company."
 msgstr ""
+"Якщо не вибрано співробітника, відділ чи посаду, оголошення буде видно всім "
+"співробітникам вибраної компанії."
 
 msgid "Description is required."
 msgstr "Потрібен опис."
@@ -4146,17 +3624,15 @@ msgstr "Скасовано"
 msgid "Cancelled & Rejected"
 msgstr "Скасовано та відхилено"
 
-#, fuzzy
-#| msgid "You dont have access to the feature"
 msgid "You dont have access to export this data"
-msgstr "У вас немає доступу до цієї функції"
+msgstr "У вас немає доступу до експорту цих даних"
 
 msgid "An employee related to this user's credentials does not exist."
 msgstr ""
 "Співробітника, пов'язаного з обліковими даними цього користувача, не існує."
 
 msgid "You must change your password before continuing."
-msgstr ""
+msgstr "Перед продовженням ви мусите змінити пароль."
 
 msgid "First Week"
 msgstr "Перший тиждень"
@@ -4188,20 +3664,14 @@ msgstr "Користувач"
 msgid "Group"
 msgstr "Група"
 
-#, fuzzy
-#| msgid "User group assigned."
 msgid "Company group assignment"
-msgstr "Групу користувачів призначено."
+msgstr "Призначення групи компанії"
 
-#, fuzzy
-#| msgid "User group assigned."
 msgid "Company group assignments"
-msgstr "Групу користувачів призначено."
+msgstr "Призначення груп компанії"
 
-#, fuzzy
-#| msgid "This work type already exists in this company"
 msgid "This department already exists in this company"
-msgstr "Цей тип роботи вже існує в цій компанії"
+msgstr "Цей відділ уже існує в цій компанії"
 
 msgid "Work Types"
 msgstr "Типи роботи"
@@ -4282,19 +3752,17 @@ msgstr "Змінні зміни"
 msgid "Select different shift continuously"
 msgstr "Послідовно вибирати іншу зміну"
 
-#, fuzzy
-#| msgid "Is Published"
 msgid "Published"
 msgstr "Опубліковано"
 
 msgid "Visible to the employee once published."
-msgstr ""
+msgstr "Видно співробітнику після публікації."
 
 msgid "Day Off"
-msgstr ""
+msgstr "Відгул"
 
 msgid "Planned weekly rest day."
-msgstr ""
+msgstr "Плановий щотижневий день відпочинку."
 
 msgid "Notes"
 msgstr "Примітки"
@@ -4303,31 +3771,25 @@ msgid "Created By"
 msgstr "Створив(ла)"
 
 msgid "Roster Entry"
-msgstr ""
+msgstr "Запис графіка"
 
 msgid "Roster Entries"
-msgstr ""
+msgstr "Записи графіка"
 
-#, fuzzy
-#| msgid "Is Published"
 msgid "Published By"
-msgstr "Опубліковано"
+msgstr "Опублікував(ла)"
 
-#, fuzzy
-#| msgid "Is Published"
 msgid "Published On"
 msgstr "Опубліковано"
 
 msgid "Total Employees"
 msgstr "Усього працівників"
 
-#, fuzzy
-#| msgid "Is Published"
 msgid "Roster Publish Log"
-msgstr "Опубліковано"
+msgstr "Журнал публікації графіка"
 
 msgid "Roster Publish Logs"
-msgstr ""
+msgstr "Журнали публікації графіка"
 
 msgid "Requesting Work Type"
 msgstr "Запитуваний тип роботи"
@@ -4395,8 +3857,6 @@ msgstr ""
 "Якщо увімкнено, відображуване ім'я братиметься від того, хто ініціював "
 "надсилання листа"
 
-#, fuzzy
-#| msgid "Use Dynamic Display Name"
 msgid "Use dynamic display name"
 msgstr "Використовуйте динамічну відображувану назву"
 
@@ -4483,10 +3943,8 @@ msgstr "Виключені діаграми"
 msgid "Dashboard Employee Charts"
 msgstr "Діаграми співробітників на панелі приладів"
 
-#, fuzzy
-#| msgid "Only one TrackLateComeEarlyOut instance is allowed."
 msgid "Only one BiometricAttendance instance is allowed per company."
-msgstr "Дозволено лише один екземпляр TrackLateComeEarlyOut."
+msgstr "Дозволено лише один екземпляр BiometricAttendance на компанію."
 
 msgid "Enable"
 msgstr "Увімкнути"
@@ -4497,15 +3955,11 @@ msgstr "Відстежувати запізнення та ранній вихі
 msgid "Track Late Come Early Outs"
 msgstr "Відстеження запізнень і ранніх виходів"
 
-#, fuzzy
-#| msgid "Only one TrackLateComeEarlyOut instance is allowed."
 msgid "Only one TrackLateComeEarlyOut instance is allowed per company."
-msgstr "Дозволено лише один екземпляр TrackLateComeEarlyOut."
+msgstr "Дозволено лише один екземпляр TrackLateComeEarlyOut на компанію."
 
-#, fuzzy
-#| msgid "Employees Specific"
 msgid "Is Specific"
-msgstr "Окремі співробітники"
+msgstr "Конкретні"
 
 msgid "Assigning Type"
 msgstr "Тип призначення"
@@ -4519,18 +3973,12 @@ msgstr "Свята"
 msgid "Leave type"
 msgstr "Тип відпустки"
 
-#, fuzzy
-#| msgid "Minus Days"
 msgid "Minus Leaves"
-msgstr "Мінус днів"
+msgstr "Мінус відпустки"
 
-#, fuzzy
-#| msgid "No Carry Forward"
 msgid "Deduct from Carry Forward"
-msgstr "Без перенесення"
+msgstr "Утримати з перенесених"
 
-#, fuzzy
-#| msgid "Penalty amount"
 msgid "Penalty Amount"
 msgstr "Сума штрафу"
 
@@ -4812,7 +4260,7 @@ msgid "Use Dynamic Display Name"
 msgstr "Використовуйте динамічну відображувану назву"
 
 msgid "Use the triggering user's name as the sender display name"
-msgstr ""
+msgstr "Використовувати ім'я користувача, який запустив, як ім'я відправника"
 
 msgid "Create reusable email body templates"
 msgstr "Створюйте багаторазові шаблони тексту електронної пошти"
@@ -4841,10 +4289,8 @@ msgstr "Назва автоматизації"
 msgid "Name of the automation rule"
 msgstr "Назва правила автоматизації"
 
-#, fuzzy
-#| msgid "Return Condition"
 msgid "Trigger Condition"
-msgstr "Стан при поверненні"
+msgstr "Умова тригера"
 
 msgid "When the automation fires: On Create Update or Delete"
 msgstr "Коли спрацьовує автоматика: у разі створення оновлення або видалення"
@@ -4869,10 +4315,8 @@ msgstr ""
 "Налаштуйте зовнішній вигляд інтерфейсу за допомогою попередньо встановлених "
 "кольорових палітр"
 
-#, fuzzy
-#| msgid "Interval duration"
 msgid "Integrations"
-msgstr "Тривалість інтервалу"
+msgstr "Інтеграції"
 
 msgid "Google Drive Backup"
 msgstr "Резервне копіювання на Google Drive"
@@ -4917,8 +4361,6 @@ msgstr "Резервне копіювання в фіксований час"
 msgid "Schedule an automatic backup at a fixed time each day"
 msgstr "Заплануйте автоматичне резервне копіювання на фіксований час щодня"
 
-#, fuzzy
-#| msgid "Linkedin Integration"
 msgid "LinkedIn Integration"
 msgstr "Інтеграція з LinkedIn"
 
@@ -4944,7 +4386,7 @@ msgid "Automatically post job openings to LinkedIn"
 msgstr "Автоматично публікуйте вакансії в LinkedIn"
 
 msgid "LDAP"
-msgstr ""
+msgstr "LDAP"
 
 msgid "Connect to LDAP for employee authentication"
 msgstr "Підключіться до LDAP для автентифікації співробітників"
@@ -4967,10 +4409,8 @@ msgstr "Базовий DN"
 msgid "LDAP base distinguished name for user search"
 msgstr "Базове розпізнаване ім’я LDAP для пошуку користувача"
 
-#, fuzzy
-#| msgid "Enable Google Meet"
 msgid "Google Meet"
-msgstr "Увімкніть Google Meet"
+msgstr "Google Meet"
 
 msgid "Configure Google Meet for interviews"
 msgstr "Налаштуйте Google Meet для співбесід"
@@ -5029,10 +4469,8 @@ msgstr "Мета номер телефону"
 msgid "WhatsApp business phone number"
 msgstr "Номер робочого телефону WhatsApp"
 
-#, fuzzy
-#| msgid "Refresh Token"
 msgid "Webhook Token"
-msgstr "Оновити токен"
+msgstr "Токен вебхука"
 
 msgid "Token for verifying WhatsApp webhook callbacks"
 msgstr "Маркер для перевірки зворотних викликів вебхука WhatsApp"
@@ -5057,19 +4495,18 @@ msgstr "Ви забанені до %(banned_until)s. Спробуйте пізн
 msgid ""
 "You have been banned for %(minutes)s minutes due to multiple failed login "
 "attempts."
-msgstr ""
+msgstr "Вас заблоковано на %(minutes)s хв. через кілька невдалих спроб входу."
 
 #, python-format
 msgid "You have %(attempts)s login attempt(s) left before a temporary ban."
 msgstr ""
+"У вас залишилось %(attempts)s спроб(и) входу до тимчасового блокування."
 
 msgid "Create "
 msgstr "Створити "
 
-#, fuzzy
-#| msgid "Document has been deleted."
 msgid "Announcement not found or has been deleted."
-msgstr "Документ видалено."
+msgstr "Оголошення не знайдено або його видалено."
 
 msgid "Are you sure you want to delete this announcement?"
 msgstr "Ви впевнені, що хочете видалити це оголошення?"
@@ -5090,7 +4527,7 @@ msgid "There are no announcements at the moment."
 msgstr "Наразі немає жодних оголошень."
 
 msgid "404"
-msgstr ""
+msgstr "404"
 
 msgid "NEW"
 msgstr "НОВЕ"
@@ -5217,14 +4654,14 @@ msgid ""
 "Name the group, then optionally choose what members can do. You can edit "
 "permissions later."
 msgstr ""
+"Назвіть групу, потім за бажанням виберіть, що можуть учасники. Дозволи можна"
+" змінити пізніше."
 
 msgid "What can this group do? (optional)"
-msgstr ""
+msgstr "Що може ця група? (необов'язково)"
 
-#, fuzzy
-#| msgid "Create "
 msgid "Create group"
-msgstr "Створити "
+msgstr "Створити групу"
 
 msgid "Reveal"
 msgstr "Розгорнути"
@@ -5246,11 +4683,11 @@ msgid ""
 "Choose employees for \"%(name)s\". Saving adds the selected employees "
 "without removing existing members."
 msgstr ""
+"Виберіть співробітників для \"%(name)s\". Збереження додає вибраних, не "
+"вилучаючи наявних."
 
-#, fuzzy
-#| msgid "Task members"
 msgid "Save members"
-msgstr "Учасники завдання"
+msgstr "Зберегти учасників"
 
 msgid "Are you sure you want to delete this group?"
 msgstr "Ви впевнені, що хочете видалити цю групу?"
@@ -5286,7 +4723,7 @@ msgid "Assign"
 msgstr "Призначити"
 
 msgid "caret down outline"
-msgstr ""
+msgstr "caret down outline"
 
 msgid "Can create"
 msgstr "Може створювати"
@@ -5300,11 +4737,8 @@ msgstr "Може редагувати"
 msgid "Can delete"
 msgstr "Може видаляти"
 
-#, fuzzy
-#| msgid "Create reusable roles and assign direct employee permissions"
 msgid "Manage reusable roles and direct employee permissions from one place."
-msgstr ""
-"Створюйте багаторазові ролі та призначайте прямі дозволи співробітникам"
+msgstr "Керуйте ролями й прямими дозволами співробітників в одному місці."
 
 msgid "Two Factor Authentication"
 msgstr "Двофакторна автентифікація"
@@ -5366,10 +4800,8 @@ msgstr "Ви впевнені, що хочете видалити цей тип 
 msgid "Encashment Settings"
 msgstr "Налаштування інкасації"
 
-#, fuzzy
-#| msgid "Configure leave and bonus point encashment rules"
 msgid "Configure bonus and leave encashment redeem conditions."
-msgstr "Налаштуйте правила інкасації відпустки та бонусних балів"
+msgstr "Налаштуйте умови обміну бонусів і компенсації відпусток."
 
 msgid "My Dashboard"
 msgstr "Моя інформаційна панель"
@@ -5381,51 +4813,35 @@ msgstr "Назад"
 msgid "Leave Balance"
 msgstr "Залишок відпустки"
 
-#, fuzzy
-#| msgid "Available days"
 msgid "Available days by type"
-msgstr "Доступні дні"
+msgstr "Доступні дні за типами"
 
-#, fuzzy
-#| msgid "Worked Hours"
 msgid "Work Hours This Week"
-msgstr "Відпрацьовані години"
+msgstr "Робочі години цього тижня"
 
-#, fuzzy
-#| msgid "My Attendances"
 msgid "My Attendance"
 msgstr "Мої відвідування"
 
-#, fuzzy
-#| msgid "Late Come"
 msgid "Late"
 msgstr "Запізнення"
 
-#, fuzzy
-#| msgid "View Payslips"
 msgid "Recent Payslips"
-msgstr "Розрахункові листки"
+msgstr "Останні розрахункові листки"
 
 msgid "Net pay vs gross pay — click to view"
-msgstr ""
+msgstr "До виплати та брутто — натисніть, щоб побачити"
 
 msgid "My Goals"
-msgstr ""
+msgstr "Мої цілі"
 
-#, fuzzy
-#| msgid "Projects in progress"
 msgid "Active objectives and progress"
-msgstr "Проєкти в процесі виконання"
+msgstr "Активні цілі та прогрес"
 
-#, fuzzy
-#| msgid "Quick Action"
 msgid "Quick Actions"
-msgstr "Швидка дія"
+msgstr "Швидкі дії"
 
-#, fuzzy
-#| msgid "My Leave"
 msgid "Apply Leave"
-msgstr "Моя відпустка"
+msgstr "Оформити відпустку"
 
 msgid "Payslips"
 msgstr "Розрахункові листки"
@@ -5433,58 +4849,38 @@ msgstr "Розрахункові листки"
 msgid "My Profile"
 msgstr "Мій профіль"
 
-#, fuzzy
-#| msgid "Leave Requests"
 msgid "Recent Leave Requests"
-msgstr "Запити на відпустку"
+msgstr "Останні заявки на відпустку"
 
-#, fuzzy
-#| msgid "View File"
 msgid "View all"
-msgstr "Переглянути файл"
+msgstr "Дивитися всі"
 
-#, fuzzy
-#| msgid "Upcoming holidays"
 msgid "Upcoming"
-msgstr "Найближчі свята"
+msgstr "Найближчі"
 
-#, fuzzy
-#| msgid "Available"
 msgid "Leave Available"
-msgstr "Доступний"
+msgstr "Доступно відпустки"
 
-#, fuzzy
-#| msgid "Remaining"
 msgid "days remaining"
-msgstr "Залишок"
+msgstr "днів залишилось"
 
-#, fuzzy
-#| msgid "This Month"
 msgid "Present This Month"
-msgstr "Цього місяця"
+msgstr "Присутні цього місяця"
 
-#, fuzzy
-#| msgid "Template"
 msgid "late"
-msgstr "Шаблон"
+msgstr "із запізненням"
 
-#, fuzzy
-#| msgid "Open Jobs"
 msgid "Open Goals"
-msgstr "Відкриті вакансії"
+msgstr "Відкриті цілі"
 
-#, fuzzy
-#| msgid "Update Objectives"
 msgid "active objectives"
-msgstr "Оновити цілі"
+msgstr "активні цілі"
 
-#, fuzzy
-#| msgid "Net Pay"
 msgid "Last Net Pay"
-msgstr "Чиста заробітна плата"
+msgstr "Остання виплата"
 
 msgid "No leave balance data"
-msgstr ""
+msgstr "Немає даних про баланс відпусток"
 
 msgid "Carry Forward"
 msgstr "Перенесення"
@@ -5492,15 +4888,11 @@ msgstr "Перенесення"
 msgid "Hours"
 msgstr "Години"
 
-#, fuzzy
-#| msgid "Target Value"
 msgid "Target"
-msgstr "Цільове значення"
+msgstr "Ціль"
 
-#, fuzzy
-#| msgid "No Candidates available."
 msgid "No payslips available"
-msgstr "Немає доступних кандидатів."
+msgstr "Немає доступних розрахункових листків"
 
 msgid "Gross Pay"
 msgstr "Валова заробітна плата"
@@ -5509,35 +4901,25 @@ msgid "Net Pay"
 msgstr "Чиста заробітна плата"
 
 msgid "No active goals"
-msgstr ""
+msgstr "Немає активних цілей"
 
-#, fuzzy
-#| msgid "Document request"
 msgid "No recent requests"
-msgstr "Запит документа"
+msgstr "Немає нових заявок"
 
-#, fuzzy
-#| msgid "Announcements"
 msgid "No announcements"
-msgstr "Оголошення"
+msgstr "Немає оголошень"
 
-#, fuzzy
-#| msgid "Today"
 msgid "Today!"
 msgstr "Сьогодні"
 
-#, fuzzy
-#| msgid "Birthday"
 msgid "Your Birthday"
-msgstr "День народження"
+msgstr "Ваш день народження"
 
 msgid "Year Anniversary"
-msgstr ""
+msgstr "Річниця"
 
-#, fuzzy
-#| msgid "No contracts ending this month"
 msgid "Nothing upcoming this month"
-msgstr "Контрактів, що завершуються цього місяця, немає"
+msgstr "Цього місяця нічого не запланово"
 
 msgid "Are you sure you want to delete this job position?"
 msgstr "Ви впевнені, що хочете видалити цю посаду?"
@@ -5558,6 +4940,8 @@ msgid ""
 "Configure outgoing email servers used for system notifications and automated"
 " messages."
 msgstr ""
+"Налаштуйте сервери вихідної пошти для системних сповіщень і автоматичних "
+"повідомлень."
 
 msgid "This mail is assigned as primary mail.Replace primary mail to delete"
 msgstr "Цю пошту призначено основною. Замініть основну пошту, щоб видалити"
@@ -5581,44 +4965,38 @@ msgid "Languages"
 msgstr "Мови"
 
 msgid "My Roster"
-msgstr ""
+msgstr "Мій графік"
 
 msgid "No published roster entries for the next 14 days."
-msgstr ""
+msgstr "Немає опублікованих записів графіка на наступні 14 днів."
 
 msgid "Leave blank to publish all entries from start date"
-msgstr ""
+msgstr "Залиште порожнім, щоб опублікувати всі записи з дати початку"
 
 msgid ""
 "All unpublished roster entries in this range will be made visible to "
 "employees."
 msgstr ""
+"Усі неопубліковані записи графіка в цьому діапазоні стануть видимими "
+"співробітникам."
 
-#, fuzzy
-#| msgid "Is Published"
 msgid "Publish"
-msgstr "Опубліковано"
+msgstr "Опублікувати"
 
 msgid "OFF"
-msgstr ""
+msgstr "ВИКЛ"
 
-#, fuzzy
-#| msgid "Date range"
 msgid "Date Range"
 msgstr "Діапазон дат"
 
-#, fuzzy
-#| msgid "No records found."
 msgid "No records"
-msgstr "Записів не знайдено."
+msgstr "Немає записів"
 
-#, fuzzy
-#| msgid "No Records found"
 msgid "No Records Found"
 msgstr "Записів не знайдено"
 
 msgid "No employees or roster entries match the current filter."
-msgstr ""
+msgstr "Жоден співробітник або запис графіка не відповідає фільтру."
 
 msgid "Select"
 msgstr "Вибрати"
@@ -5626,39 +5004,29 @@ msgstr "Вибрати"
 msgid "Unselect"
 msgstr "Скасувати вибір"
 
-#, fuzzy
-#| msgid "Confirm Password"
 msgid "Confirm Publish"
-msgstr "Підтвердіть пароль"
+msgstr "Підтвердіть публікацію"
 
 msgid "cloud upload"
 msgstr "cloud upload"
 
-#, fuzzy
-#| msgid "Download Template"
 msgid "Download Roster Template"
-msgstr "Завантажити шаблон"
+msgstr "Завантажити шаблон графіка"
 
-#, fuzzy
-#| msgid "Please select a valid date format."
 msgid "Please select both dates."
-msgstr "Будь ласка, виберіть коректний формат дати."
+msgstr "Виберіть обидві дати."
 
-#, fuzzy
-#| msgid "End date cannot be less than start date."
 msgid "End date cannot be before start date."
-msgstr "Дата завершення не може бути раніше за дату початку."
+msgstr "Дата завершення не може бути раніше дати початку."
 
 msgid "No Entries Imported"
-msgstr ""
+msgstr "Записів не імпортовано"
 
 msgid "All rows were either blank, skipped, or had errors."
-msgstr ""
+msgstr "Усі рядки були порожні, пропущені або з помилками."
 
-#, fuzzy
-#| msgid "Import Employee"
 msgid "Roster Import Complete"
-msgstr "Імпорт співробітника"
+msgstr "Імпорт графіка завершено"
 
 msgid "Created"
 msgstr "Створено"
@@ -5667,14 +5035,14 @@ msgid "Updated"
 msgstr "Оновлено"
 
 msgid "Skipped"
-msgstr ""
+msgstr "Пропущено"
 
 #, python-format
 msgid "%(n)s error"
 msgid_plural "%(n)s errors"
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%(n)s помилка"
+msgstr[1] "%(n)s помилки"
+msgstr[2] "%(n)s помилок"
 
 msgid "Done"
 msgstr "Виконано"
@@ -5797,19 +5165,20 @@ msgstr "Ви хочете розархівувати це призначення
 msgid "Are you sure you want to delete this rotating work type?"
 msgstr "Ви впевнені, що хочете видалити цей ротаційний тип роботи?"
 
-#, fuzzy
-#| msgid "Choose which models are recorded in the audit log"
 msgid ""
 "Manage history tags and configure which models and fields are tracked in the"
 " audit log."
-msgstr "Виберіть, які моделі записуються в журнал аудиту"
+msgstr ""
+"Керуйте тегами історії й налаштовуйте, які моделі та поля відстежуються в "
+"журналі аудиту."
 
 msgid ""
 "Create and manage tags used to categorise records in the audit history log."
 msgstr ""
+"Створюйте й керуйте тегами для категоризації записів у журналі аудиту."
 
 msgid "Define recurring company-wide off days based on the week and weekday."
-msgstr ""
+msgstr "Визначте повторювані загальні вихідні дні за тижнем і днем тижня."
 
 msgid "Select Date Format:"
 msgstr "Оберіть формат дати:"
@@ -5865,9 +5234,6 @@ msgstr "12-годинний (напр., 06:00 AM або 06:00 PM)"
 msgid "24 Hr. (e.g., 06:00 or 18:00)"
 msgstr "24-годинний (напр., 06:00 або 18:00)"
 
-#, fuzzy
-#| msgid ""
-#| "Control the default data export behavior for the currently selected company"
 msgid ""
 "Control the default data export behavior for the currently selected company."
 msgstr ""
@@ -5875,183 +5241,146 @@ msgstr ""
 "компанії"
 
 msgid "Allow All Users to Export Data"
-msgstr ""
+msgstr "Дозволити всім користувачам експорт даних"
 
 msgid ""
 "When enabled, every user of this company can export data from any module. "
 "When disabled, only users (or superusers) with the appropriate export "
 "permission for a module can export its data."
 msgstr ""
+"Якщо увімкнено, кожен користувач цієї компанії може експортувати дані з "
+"будь-якого модуля. Якщо вимкнено, експортувати дані модуля можуть лише "
+"користувачі (або суперюзери) з відповідним дозволом на експорт."
 
 msgid "Allow every user of this company to export data from any module."
 msgstr ""
+"Дозволити кожному користувачу цієї компанії експорт даних з будь-якого "
+"модуля."
 
-#, fuzzy
-#| msgid ""
-#| "Are you sure you want to allow all employees to edit their profiles?"
 msgid "Are you sure you want to allow all users to export data?"
-msgstr ""
-"Ви впевнені, що хочете дозволити всім співробітникам редагувати свої "
-"профілі?"
+msgstr "Ви впевнені, що хочете дозволити всім користувачам експорт даних?"
 
-#, fuzzy
-#| msgid ""
-#| "Are you sure you want to restrict all employees from editing their profiles?"
 msgid ""
 "Are you sure you want to restrict data export to users with export "
 "permission?"
 msgstr ""
-"Ви впевнені, що хочете заборонити всім співробітникам редагувати свої "
-"профілі?"
+"Ви впевнені, що хочете обмежити експорт даних лише користувачам із дозволом "
+"на експорт?"
 
 msgid "Define company-observed public holidays and recurring holiday dates."
-msgstr ""
+msgstr "Визначте державні свята компанії та повторювані святкові дати."
 
 msgid "Import Holidays"
 msgstr "Імпортувати свята"
 
-#, fuzzy
-#| msgid "All companies"
 msgid "All Companies (Default)"
-msgstr "Усі компанії"
+msgstr "Усі компанії (за замовчуванням)"
 
-#, fuzzy
-#| msgid "Company State"
 msgid "Company Settings"
-msgstr "Стан компанії"
+msgstr "Налаштування компанії"
 
 msgid "These language settings only apply to the selected company."
-msgstr ""
+msgstr "Ці налаштування мови застосовуються лише до вибраної компанії."
 
-#, fuzzy
-#| msgid "Select the company."
 msgid "Selected Company"
-msgstr "Виберіть компанію."
+msgstr "Вибрана компанія"
 
-#, fuzzy
-#| msgid "Languages"
 msgid "Languages Enabled"
-msgstr "Мови"
+msgstr "Увімкнені мови"
 
-#, fuzzy
-#| msgid "configuration"
 msgid "Default configuration"
-msgstr "конфігурація"
+msgstr "Конфігурація за замовчуванням"
 
 msgid "Loading language settings…"
-msgstr ""
+msgstr "Завантаження налаштувань мови…"
 
 msgid ""
 "Since only one company exists, these settings will automatically apply to "
 "it."
 msgstr ""
+"Оскільки існує лише одна компанія, ці налаштування застосуються до неї "
+"автоматично."
 
 #, python-format
 msgid ""
 "Employees belonging to \"%(company_name)s\" will only see the languages "
 "enabled below in their language switcher."
 msgstr ""
+"Співробітники компанії \"%(company_name)s\" бачитимуть у перемикачі лише "
+"мови, увімкнені нижче."
 
 msgid ""
 "You're editing the default language configuration, used by any company that "
 "hasn't set its own languages."
 msgstr ""
+"Ви редагуєте типову конфігурацію мов, яку використовує будь-яка компанія без"
+" власних налаштувань."
 
 msgid ""
 "Changing to another company loads that company's own language configuration."
-msgstr ""
+msgstr "Перехід до іншої компанії завантажує її власну конфігурацію мов."
 
-#, fuzzy
-#| msgid "Create Company Leaves"
 msgid "Current Company"
-msgstr "Створити відпустки компанії"
+msgstr "Поточна компанія"
 
-#, fuzzy
-#| msgid "None available"
 msgid "Languages Available"
-msgstr "Недоступний"
+msgstr "Доступні мови"
 
-#, fuzzy
-#| msgid "Configure"
 msgid "Configured On"
-msgstr "Налаштувати"
+msgstr "Налаштовано"
 
-#, fuzzy
-#| msgid "Not set"
 msgid "Not yet"
-msgstr "Не встановлено"
+msgstr "Ще ні"
 
-#, fuzzy
-#| msgid "Enable Languages"
 msgid "Managing Languages For"
-msgstr "Увімкнути мови"
+msgstr "Керування мовами для"
 
-#, fuzzy
-#| msgid "Search %(name)s"
 msgid "Search languages…"
-msgstr "Пошук %(name)s"
+msgstr "Пошук мов…"
 
-#, fuzzy
-#| msgid "Search %(name)s"
 msgid "Search languages"
-msgstr "Пошук %(name)s"
+msgstr "Пошук мов"
 
 msgid "Selected"
 msgstr "Вибрано"
 
-#, fuzzy
-#| msgid "Enable"
 msgid "Enable All"
-msgstr "Увімкнути"
+msgstr "Увімкнути все"
 
-#, fuzzy
-#| msgid "disabled"
 msgid "Disable All"
-msgstr "вимкнено"
+msgstr "Вимкнути все"
 
-#, fuzzy
-#| msgid "No assets have been allocated."
 msgid "No languages have been enabled."
-msgstr "Активи не було виділено."
+msgstr "Жодна мова не увімкнена."
 
 msgid "Employees will not be able to switch languages."
-msgstr ""
+msgstr "Співробітники не зможуть перемикати мови."
 
-#, fuzzy
-#| msgid "Available Leaves"
 msgid "Available languages"
-msgstr "Доступні відпустки"
+msgstr "Доступні мови"
 
-#, fuzzy, python-format
-#| msgid "Enable Face"
+#, python-format
 msgid "Enable %(label)s"
-msgstr "Увімкнути розпізнавання обличчя"
+msgstr "Увімкнути %(label)s"
 
 msgid "No languages match your search."
-msgstr ""
+msgstr "Жодна мова не відповідає пошуку."
 
-#, fuzzy
-#| msgid "Save Changes"
 msgid "Unsaved changes"
-msgstr "Зберегти зміни"
+msgstr "Незбережені зміни"
 
-#, fuzzy
-#| msgid "Create and manage reusable permission roles"
 msgid ""
 "Create and manage reusable email templates for system notifications and "
 "workflows."
-msgstr "Створюйте багаторазові ролі дозволів і керуйте ними"
+msgstr ""
+"Створюйте й керуйте шаблонами листів для системних сповіщень і процесів."
 
-#, fuzzy
-#| msgid "Do you want to delete this template"
 msgid "Do you want to delete this template?"
 msgstr "Бажаєте видалити цей шаблон"
 
 msgid "View Template"
 msgstr "Переглянути шаблон"
 
-#, fuzzy
-#| msgid "No records found."
 msgid "No records found"
 msgstr "Записів не знайдено."
 
@@ -6064,10 +5393,8 @@ msgstr ""
 "Налаштуйте системні значення за замовчуванням, форматування та контроль "
 "доступу."
 
-#, fuzzy
-#| msgid "General Settings"
 msgid "General Defaults"
-msgstr "Загальні налаштування"
+msgstr "Загальні значення за замовчуванням"
 
 msgid "Formatting & Localization"
 msgstr "Форматування та локалізація"
@@ -6076,7 +5403,7 @@ msgid "Data & Access Controls"
 msgstr "Контроль даних і доступу"
 
 msgid "HR setup checklist"
-msgstr ""
+msgstr "Чек-лист налаштування HR"
 
 msgid "Get started with Horilla HR"
 msgstr "Початок роботи з Horilla HR"
@@ -6095,15 +5422,13 @@ msgid "finish setup to unlock your full HR system"
 msgstr "Завершіть налаштування, щоб відкрити повну HR-систему"
 
 msgid "Dismiss setup checklist"
-msgstr ""
+msgstr "Приховати чек-лист налаштування"
 
 msgid "Setup steps"
-msgstr ""
+msgstr "Кроки налаштування"
 
-#, fuzzy
-#| msgid "Next Step"
 msgid "Next setup step"
-msgstr "Наступний крок"
+msgstr "Наступний крок налаштування"
 
 #, python-format
 msgid ""
@@ -6122,13 +5447,9 @@ msgstr "Налаштувати %(title)s"
 msgid "Set up now"
 msgstr "Налаштувати зараз"
 
-#, fuzzy
-#| msgid "Completed"
 msgid "complete"
-msgstr "Завершено"
+msgstr "завершено"
 
-#, fuzzy
-#| msgid "Next Step"
 msgid "next step"
 msgstr "Наступний крок"
 
@@ -6171,15 +5492,11 @@ msgstr "Ви впевнені, що хочете видалити цей тип 
 msgid "Are you sure you want to delete this work type?"
 msgstr "Ви впевнені, що хочете видалити цей тип роботи?"
 
-#, fuzzy
-#| msgid "Company Logo"
 msgid "Company logo"
 msgstr "Логотип компанії"
 
-#, fuzzy
-#| msgid "Upload Photo"
 msgid "Upload Logo"
-msgstr "Завантажити фото"
+msgstr "Завантажити логотип"
 
 msgid "Based On week"
 msgstr "На основі тижня"
@@ -6196,24 +5513,18 @@ msgstr "Експортувати свята"
 msgid "Hint: Type '{' to get sender or receiver data"
 msgstr "Підказка: введіть '{', щоб отримати дані відправника або одержувача"
 
-#, fuzzy
-#| msgid "Manager"
 msgid "Add Manager"
-msgstr "Керівник"
+msgstr "Додати керівника"
 
 msgid "Export Rotating Shift Assigns"
 msgstr "Експортувати призначення позмінної ротації"
 
-#, fuzzy
-#| msgid "Do you want to un-archive this rotating work type assign?"
 msgid "Do you want to Un-archive this rotating work type assign?"
 msgstr "Ви хочете розархівувати це призначення ротаційного типу роботи?"
 
 msgid "Export Rotating Work Type Assigns"
 msgstr "Експортувати призначення ротаційного типу роботи"
 
-#, fuzzy
-#| msgid "Primary mail is not configured! "
 msgid "Primary mail is not configured!"
 msgstr "Основну пошту не налаштовано! "
 
@@ -6221,7 +5532,7 @@ msgid "Test email"
 msgstr "Тестовий лист"
 
 msgid "at-circle-outline"
-msgstr ""
+msgstr "at-circle-outline"
 
 msgid "Do you want to delete this mail server configuration?"
 msgstr "Ви хочете видалити цю конфігурацію поштового сервера?"
@@ -6301,10 +5612,8 @@ msgstr "Текст"
 msgid "Save Duplicate"
 msgstr "Зберегти копію"
 
-#, fuzzy
-#| msgid "Theme Manager"
 msgid "Remove manager"
-msgstr "Менеджер тем"
+msgstr "Видалити керівника"
 
 msgid "Multiple Approval Condition"
 msgstr "Умова множинного затвердження"
@@ -6888,10 +6197,8 @@ msgstr "stage-view"
 msgid "view-onboarding-dashboard"
 msgstr "view-onboarding-dashboard"
 
-#, fuzzy
-#| msgid "pipeline"
 msgid "cbv-pipeline"
-msgstr "воронка підбору"
+msgstr "Воронка підбору"
 
 msgid "onboarding-view"
 msgstr "onboarding-view"
@@ -7043,10 +6350,8 @@ msgstr "нарахування зарплати"
 msgid "employee"
 msgstr "співробітник"
 
-#, fuzzy
-#| msgid "color-settings"
 msgid "employee-settings"
-msgstr "налаштування кольорів"
+msgstr "Налаштування співробітників"
 
 msgid "onboarding"
 msgstr "адаптація"
@@ -7375,147 +6680,95 @@ msgstr "звіт з активів"
 msgid "pms-report"
 msgstr "звіт pms"
 
-#, fuzzy
-#| msgid "Linkedin Integration"
 msgid "linkedin-integration-setting"
-msgstr "Інтеграція з LinkedIn"
+msgstr "Інтеграція LinkedIn"
 
-#, fuzzy
-#| msgid "date-settings"
 msgid "ldap-settings"
-msgstr "налаштування дат"
+msgstr "Налаштування LDAP"
 
-#, fuzzy
-#| msgid "general-settings"
 msgid "gmeet-setting"
-msgstr "загальні налаштування"
+msgstr "Налаштування Google Meet"
 
 msgid "whatsapp-credential-view"
-msgstr ""
+msgstr "Облікові дані WhatsApp"
 
 msgid "meet"
-msgstr ""
+msgstr "зустріч"
 
-#, fuzzy
-#| msgid "request-view"
 msgid "gmeet-view"
-msgstr "перегляд запиту"
+msgstr "Google Meet"
 
-#, fuzzy
-#| msgid "WhatsApp"
 msgid "whatsapp"
 msgstr "WhatsApp"
 
-#, fuzzy
-#| msgid "work-type-view"
 msgid "color-theme-view"
-msgstr "перегляд типу роботи"
+msgstr "Колірна тема"
 
-#, fuzzy
-#| msgid "question-template-view"
 msgid "survey-template-preview"
-msgstr "перегляд шаблону запитань"
+msgstr "Перегляд шаблону опитування"
 
 msgid "theme"
-msgstr ""
+msgstr "тема"
 
-#, fuzzy
-#| msgid "objective-list-view"
 msgid "objective-template-list-view"
-msgstr "перегляд списку цілей"
+msgstr "Шаблони цілей"
 
 msgid "roster"
-msgstr ""
+msgstr "графік"
 
-#, fuzzy
-#| msgid "Biometric Devices"
 msgid "view-biometric-devices"
 msgstr "Біометричні пристрої"
 
-#, fuzzy
-#| msgid "Anviz Biometric"
 msgid "biometric"
-msgstr "Біометрія Anviz"
+msgstr "біометрія"
 
-#, fuzzy
-#| msgid "asset-history"
 msgid "audit-history"
-msgstr "історія активу"
+msgstr "Історія змін"
 
-#, fuzzy
-#| msgid "Policies & Discipline"
 msgid "policies-discipline"
-msgstr "Політика та дисципліна"
+msgstr "Політики та дисципліна"
 
-#, fuzzy
-#| msgid "Work Schedules"
 msgid "work-schedules"
 msgstr "Графіки роботи"
 
-#, fuzzy
-#| msgid "requested"
 msgid "requests"
-msgstr "запитано"
+msgstr "заявки"
 
-#, fuzzy
-#| msgid "Hours"
 msgid "tours"
-msgstr "Години"
+msgstr "тури"
 
-#, fuzzy
-#| msgid "Templates"
 msgid "templates-periods"
-msgstr "Шаблони"
+msgstr "Шаблони та періоди"
 
-#, fuzzy
-#| msgid "System Preferences"
 msgid "system-preferences-view"
 msgstr "Системні налаштування"
 
-#, fuzzy
-#| msgid "Default Export Access"
 msgid "default-export-access"
 msgstr "Стандартний доступ до експорту"
 
-#, fuzzy
-#| msgid "attendance-view"
 msgid "attendance-rule-view"
-msgstr "attendance-view"
+msgstr "Правила відвідуваності"
 
-#, fuzzy
-#| msgid "leave-allocation-request-view"
 msgid "leave-rules-view"
-msgstr "перегляд запиту на розподіл відпустки"
+msgstr "Правила відпусток"
 
-#, fuzzy
-#| msgid "attendance-settings-view"
 msgid "encashment-settings-view"
-msgstr "перегляд налаштувань відвідуваності"
+msgstr "Налаштування компенсацій"
 
-#, fuzzy
-#| msgid "onboarding-view"
 msgid "offboarding-rules-view"
-msgstr "onboarding-view"
+msgstr "Правила звільнення"
 
-#, fuzzy
-#| msgid "company-leave-view"
 msgid "company-leaves-view"
-msgstr "перегляд відпусток компанії"
+msgstr "Відпустки компанії"
 
-#, fuzzy
-#| msgid "view-mail-templates"
 msgid "mail-templates-view"
-msgstr "перегляд шаблонів листів"
+msgstr "Шаблони листів"
 
-#, fuzzy
-#| msgid "mail-automations"
 msgid "mail-automations-view"
-msgstr "автоматизація листів"
+msgstr "Автоматизація листів"
 
-#, fuzzy
-#| msgid "Employee Work Information"
 msgid "Employee Work Info"
-msgstr "Робоча інформація про співробітника"
+msgstr "Робоча інформація"
 
 msgid "Online Employees"
 msgstr "Співробітники онлайн"
@@ -7586,11 +6839,11 @@ msgstr "Базу даних успішно завантажено."
 
 #, python-format
 msgid "Assigned demo roles to %(count)s employee memberships."
-msgstr ""
+msgstr "Демо-ролі призначено для %(count)s членств співробітників."
 
 #, python-format
 msgid "Demo roles could not be assigned: %(error)s"
-msgstr ""
+msgstr "Демо-ролі не вдалося призначити: %(error)s"
 
 msgid "Database Authentication Failed"
 msgstr "Помилка автентифікації бази даних"
@@ -7620,7 +6873,7 @@ msgid "Password reset link sent successfully"
 msgstr "Посилання для скидання пароля успішно надіслано"
 
 msgid "If your account exists, a password reset link has been sent"
-msgstr ""
+msgstr "Якщо ваш акаунт існує, посилання для скидання пароля надіслано"
 
 msgid "Something went wrong....."
 msgstr "Щось пішло не так....."
@@ -7637,64 +6890,44 @@ msgstr "Термін дії OTP минув. Будь ласка, попросі�
 msgid "Invalid OTP."
 msgstr "Недійсний OTP."
 
-#, fuzzy
-#| msgid "Allowance created."
 msgid "Role created."
-msgstr "Надбавку створено."
+msgstr "Роль створено."
 
-#, fuzzy
-#| msgid "Period not found."
 msgid "Group not found"
-msgstr "Період не знайдено."
+msgstr "Групу не знайдено"
 
-#, fuzzy
-#| msgid "You dont have permission"
 msgid "Updated the permissions"
-msgstr "У вас немає дозволу"
+msgstr "Дозволи оновлено"
 
-#, fuzzy
-#| msgid "Value updated"
 msgid "Name updated"
-msgstr "Значення оновлено"
+msgstr "Назву оновлено"
 
 msgid "At least 4 characters required"
-msgstr ""
+msgstr "Потрібно щонайменше 4 символи"
 
-#, fuzzy
-#| msgid "All filter cleared"
 msgid "All permission cleared"
-msgstr "Усі фільтри очищено"
+msgstr "Усі дозволи очищено"
 
 msgid "Something went wrong"
 msgstr "Щось пішло не так"
 
-#, fuzzy
-#| msgid "Missing required parameter: ids"
 msgid "Required parameters are missing"
-msgstr "Відсутній обов’язковий параметр: ідентифікатори"
+msgstr "Відсутні обов'язкові параметри"
 
-#, fuzzy
-#| msgid "Profile image updated."
 msgid "Role members updated."
-msgstr "Зображення профілю оновлено."
+msgstr "Учасників ролі оновлено."
 
-#, fuzzy
-#| msgid "Work type request added."
 msgid "Role members added."
-msgstr "Запит на зміну типу роботи додано."
+msgstr "Учасників ролі додано."
 
-#, fuzzy
-#| msgid "Employee has been successfully removed from the meeting."
 msgid "Employee removed from the group."
-msgstr "Співробітника успішно видалено із зустрічі."
+msgstr "Співробітника вилучено з групи."
 
 msgid "Company removed from the employee's assignment."
-msgstr ""
+msgstr "Компанію вилучено з призначень співробітника."
 
-#, fuzzy
-#| msgid "Are you sure want to remove this employee from this action?"
 msgid "Unable to remove employee from the group."
-msgstr "Ви впевнені, що хочете видалити цього співробітника з цього заходу?"
+msgstr "Не вдалося вилучити співробітника з групи."
 
 msgid "The {} has been deleted successfully."
 msgstr "{} успішно видалено."
@@ -7715,31 +6948,23 @@ msgstr "Щось пішло не так:"
 msgid "Mail sent successfully"
 msgstr "Лист успішно надіслано"
 
-#, fuzzy
-#| msgid "Missing required parameters"
 msgid "Missing required parameter"
-msgstr "Відсутні необхідні параметри"
+msgstr "Відсутній обов'язковий параметр"
 
-#, fuzzy
-#| msgid "Employee work information not found."
 msgid "Mail server configuration not found"
-msgstr "Робочу інформацію працівника не знайдено."
+msgstr "Конфігурацію поштового сервера не знайдено"
 
 msgid "You have only 1 Mail server configuration that can't be deleted"
-msgstr ""
+msgstr "У вас лише одна конфігурація поштового сервера, її не можна видалити"
 
 msgid "Can't Delete"
 msgstr "Неможливо видалити"
 
-#, fuzzy
-#| msgid "Email server is not configured"
 msgid "Mail server configuration deleted"
-msgstr "Сервер електронної пошти не налаштовано"
+msgstr "Конфігурацію поштового сервера видалено"
 
-#, fuzzy
-#| msgid "Primary mail server is not configured"
 msgid "Primary Mail server configuration replaced"
-msgstr "Основний поштовий сервер не налаштовано"
+msgstr "Основну конфігурацію поштового сервера замінено"
 
 msgid "Template updated"
 msgstr "Шаблон оновлено"
@@ -7795,10 +7020,8 @@ msgstr "Призначення змінного типу роботи {}"
 msgid "Rotating work type assign not found."
 msgstr "Призначення змінного типу роботи не знайдено."
 
-#, fuzzy
-#| msgid "No Attachment found matching the query."
 msgid "No rotatingworktype found matching the query."
-msgstr "Вкладень, що відповідають запиту, не знайдено."
+msgstr "Змінних типів роботи за цим запитом не знайдено."
 
 #, python-brace-format
 msgid "Rotating work type for {employee_id} already exists"
@@ -7862,10 +7085,8 @@ msgstr "Призначення змінної зміни {}"
 msgid "Rotating shift assign not found."
 msgstr "Призначення змінної зміни не знайдено."
 
-#, fuzzy
-#| msgid "No Attachment found matching the query."
 msgid "No rotatingshift found matching the query."
-msgstr "Вкладень, що відповідають запиту, не знайдено."
+msgstr "Змінних змін за цим запитом не знайдено."
 
 #, python-brace-format
 msgid "Rotating shift for {employee} is {message}"
@@ -7896,10 +7117,8 @@ msgstr "Ви не можете видалити це призначення зм
 msgid "Employee not provided"
 msgstr "Співробітника не вказано"
 
-#, fuzzy
-#| msgid "Question updated successfully."
 msgid "Permissions updated successfully"
-msgstr "Запитання успішно оновлено."
+msgstr "Дозволи успішно оновлено"
 
 msgid "Employee not found"
 msgstr "Працівника не знайдено"
@@ -7919,10 +7138,8 @@ msgstr "У вас немає прав доступу"
 msgid "Work type request has been rejected."
 msgstr "Запит на зміну типу роботи відхилено."
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No worktype request found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Заявок на тип роботи за цим запитом не знайдено."
 
 msgid "Work type request has been canceled."
 msgstr "Запит на зміну типу роботи скасовано."
@@ -7945,18 +7162,14 @@ msgstr ""
 "Ви не можете видалити запит на зміну типу роботи співробітника {employee} на"
 " дату {date}."
 
-#, fuzzy
-#| msgid "Work type request deleted."
 msgid "{} work type requests deleted."
-msgstr "Запит на зміну типу роботи видалено."
+msgstr "{} заявок на тип роботи видалено."
 
 msgid "Shift request added"
 msgstr "Запит на зміну зміни додано"
 
-#, fuzzy
-#| msgid "No Attachment found matching the query."
 msgid "No shift found matching the query."
-msgstr "Вкладень, що відповідають запиту, не знайдено."
+msgstr "Змін за цим запитом не знайдено."
 
 msgid "Request Added"
 msgstr "Запит додано"
@@ -7970,10 +7183,8 @@ msgstr "Неможливо редагувати схвалений запит н
 msgid "Shift request rejected"
 msgstr "Запит на зміну відхилено"
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No shift request found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Заявок на зміну за цим запитом не знайдено."
 
 msgid "Shift request canceled"
 msgstr "Запит на зміну скасовано"
@@ -7999,10 +7210,8 @@ msgstr ""
 "Ви не можете видалити запит на зміну співробітника {employee} на дату "
 "{date}."
 
-#, fuzzy
-#| msgid "Shift request deleted."
 msgid "{} shift requests deleted."
-msgstr "Запит на зміну видалено."
+msgstr "{} заявок на зміну видалено."
 
 msgid "Unread notifications removed."
 msgstr "Непрочитані сповіщення видалено."
@@ -8013,15 +7222,11 @@ msgstr "Усі сповіщення видалено."
 msgid "Notification deleted."
 msgstr "Сповіщення видалено."
 
-#, fuzzy
-#| msgid "Notification Sound"
 msgid "Notification not found."
-msgstr "Звук сповіщення"
+msgstr "Сповіщення не знайдено."
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No notification found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Сповіщень за цим запитом не знайдено."
 
 msgid "Notifications marked as read"
 msgstr "Сповіщення позначено як прочитані"
@@ -8029,10 +7234,8 @@ msgstr "Сповіщення позначено як прочитані"
 msgid "Settings updated."
 msgstr "Налаштування оновлено."
 
-#, fuzzy
-#| msgid "Invalid end date format."
 msgid "Invalid date format."
-msgstr "Невірний формат дати завершення."
+msgstr "Невірний формат дати."
 
 msgid "Please select a valid date format."
 msgstr "Будь ласка, виберіть коректний формат дати."
@@ -8058,10 +7261,8 @@ msgstr "Формат часу неможливо зберегти. Ви не н�
 msgid "Profile edit accessibility feature has been removed."
 msgstr "Функцію редагування профілю вимкнено."
 
-#, fuzzy
-#| msgid "Your work details has been updated."
 msgid "Language settings have been updated."
-msgstr "Ваші робочі дані оновлено."
+msgstr "Налаштування мови оновлено."
 
 msgid "Tag has been created successfully!"
 msgstr "Тег успішно створено!"
@@ -8078,10 +7279,8 @@ msgstr "Керівник із затвердження {}"
 msgid "Multiple approval condition updated successfully"
 msgstr "Умову багаторівневого затвердження успішно оновлено"
 
-#, fuzzy
-#| msgid "Matching query does not exists."
 msgid "No MultipleApprovalCondition matching query does not exist."
-msgstr "Відповідний запит не існує."
+msgstr "MultipleApprovalCondition за цим запитом не існує."
 
 msgid "Multiple approval condition deleted successfully"
 msgstr "Умову багаторівневого затвердження успішно видалено"
@@ -8107,10 +7306,8 @@ msgstr ""
 msgid "Action has been deleted successfully!"
 msgstr "Дію успішно видалено!"
 
-#, fuzzy
-#| msgid "Batch updated successfully."
 msgid "Dashboard charts updated successfully"
-msgstr "Партію успішно оновлено."
+msgstr "Діаграми дашборду успішно оновлено"
 
 msgid "The biometric attendance feature has been activated successfully."
 msgstr "Функцію біометричного обліку відвідуваності успішно активовано."
@@ -8169,15 +7366,11 @@ msgstr "Відпустку компанії успішно видалено.."
 msgid "Company leave not found."
 msgstr "Відпустку компанії не знайдено."
 
-#, fuzzy
-#| msgid "No Attachment found matching the query."
 msgid "No penalty account found matching the query."
-msgstr "Вкладень, що відповідають запиту, не знайдено."
+msgstr "Рахунків штрафів за цим запитом не знайдено."
 
-#, fuzzy
-#| msgid "Asset deleted successfully"
 msgid "Penalty deleted suucessfully"
-msgstr "Актив успішно видалено"
+msgstr "Штраф успішно видалено"
 
 msgid "Missing app_label"
 msgstr "Відсутня app_label"
@@ -8193,15 +7386,12 @@ msgstr "%(app_verbose_name)s вимкнено"
 msgid "Biometric Devices"
 msgstr "Біометричні пристрої"
 
-#, fuzzy, python-format
-#| msgid "Do you want to archive this ticket?"
+#, python-format
 msgid "Do you want to %(status)s this device?"
-msgstr "Бажаєте заархівувати цю заявку?"
+msgstr "Ви бажаєте %(status)s цей пристрій?"
 
-#, fuzzy
-#| msgid "Do you want to delete this record?"
 msgid "Do you want to delete this device?"
-msgstr "Ви бажаєте видалити цей запис?"
+msgstr "Ви бажаєте видалити цей пристрій?"
 
 msgid "Fetch Logs"
 msgstr "Отримати журнали"
@@ -8212,23 +7402,17 @@ msgstr "Тип пристрою"
 msgid "Not-Connected"
 msgstr "Не підключено"
 
-#, fuzzy
-#| msgid "Scheduled"
 msgid "Sheduled"
 msgstr "Заплановано"
 
 msgid "Live Capture"
 msgstr "Живе захоплення"
 
-#, fuzzy
-#| msgid "Biometric Device"
 msgid "Add Biometric Device"
-msgstr "Біометричний пристрій"
+msgstr "Додати біометричний пристрій"
 
-#, fuzzy
-#| msgid "Biometric Devices"
 msgid "Edit Biometric Devices"
-msgstr "Біометричні пристрої"
+msgstr "Редагувати біометричні пристрої"
 
 msgid "Biometric device updated successfully."
 msgstr "Біометричний пристрій успішно оновлено."
@@ -8236,8 +7420,6 @@ msgstr "Біометричний пристрій успішно оновлен�
 msgid "Biometric device added successfully."
 msgstr "Біометричний пристрій успішно додано."
 
-#, fuzzy
-#| msgid "Schedule Biometric Device"
 msgid "Schedule Biometric Device.."
 msgstr "Розклад біометричного пристрою"
 
@@ -8402,10 +7584,8 @@ msgstr "Аргументи відвідуваності COSEC"
 msgid "Test"
 msgstr "Тест"
 
-#, fuzzy
-#| msgid "Do you want to unarchive this meeting?"
 msgid "Do you want to unschedule the device attendance fetching?"
-msgstr "Ви бажаєте розархівувати цю зустріч?"
+msgstr "Ви бажаєте скасувати розклад отримання відвідуваності з пристрою?"
 
 msgid "Unschedule"
 msgstr "Скасувати розклад"
@@ -8509,20 +7689,14 @@ msgstr "Прив'язати співробітника"
 msgid "Emp Code"
 msgstr "Код співробітника"
 
-#, fuzzy
-#| msgid "e-Time Office"
 msgid "Map e-Time Office User"
-msgstr "e-Time Office"
+msgstr "Зіставити користувача e-Time Office"
 
-#, fuzzy
-#| msgid "Device"
 msgid "Device:"
 msgstr "Пристрій"
 
-#, fuzzy
-#| msgid "Deduction"
 msgid "Direction:"
-msgstr "Відрахування"
+msgstr "Напрямок:"
 
 msgid "Biometric device unscheduled successfully"
 msgstr "Розклад біометричного пристрою успішно скасовано"
@@ -8695,92 +7869,62 @@ msgstr "Блокування входу"
 msgid "Disciplinary Action Type"
 msgstr "Тип дисциплінарного стягнення"
 
-#, fuzzy
-#| msgid "The comment updated successfully."
 msgid "The action type updated successfully."
-msgstr "Коментар успішно оновлено."
+msgstr "Тип дії успішно оновлено."
 
-#, fuzzy
-#| msgid "The Ticket created successfully."
 msgid "The action type created successfully."
-msgstr "Заявку успішно створено."
+msgstr "Тип дії успішно створено."
 
-#, fuzzy
-#| msgid "You cannot delete this candidate"
 msgid "Allocation feature not possible to this candidate"
-msgstr "Ви не можете видалити цього кандидата"
+msgstr "Функція розподілу неможлива для цього кандидата"
 
 msgid "Summary"
 msgstr "Підсумок"
 
-#, fuzzy
-#| msgid "Contract name"
 msgid "Contact name"
-msgstr "Назва контракту"
+msgstr "Ім'я контакту"
 
-#, fuzzy
-#| msgid "Emergency Contact Relation"
 msgid "Contact Relation"
-msgstr "Ступінь спорідненості контакту для екстрених випадків"
+msgstr "Ступінь спорідненості"
 
-#, fuzzy
-#| msgid "Personal Information"
 msgid "Personal Information Updated"
-msgstr "Особиста інформація"
+msgstr "Особисту інформацію оновлено"
 
-#, fuzzy
-#| msgid "Work Info"
 msgid "Work Info Updated"
-msgstr "Робоча інформація"
+msgstr "Робочу інформацію оновлено"
 
-#, fuzzy
-#| msgid "Bank Info"
 msgid "Bank Info Updated"
-msgstr "Банківська інформація"
+msgstr "Банківські дані оновлено"
 
-#, fuzzy
-#| msgid "Policy"
 msgid "Leave Policy"
-msgstr "Політика"
+msgstr "Політика відпусток"
 
-#, fuzzy
-#| msgid "Assigned To"
 msgid "Assigned "
-msgstr "Призначено"
+msgstr "Призначено "
 
 msgid "Cannot Assign or Already Assigned"
-msgstr ""
+msgstr "Не можна призначити або вже призначено"
 
 msgid "Select Types to Assign"
-msgstr ""
+msgstr "Виберіть типи для призначення"
 
-#, fuzzy
-#| msgid "Selected Assets"
 msgid "Selected Available Assets Allocated"
-msgstr "Вибрані активи"
+msgstr "Вибрані доступні активи видано"
 
-#, fuzzy
-#| msgid "Selected Assets"
 msgid "Select Available Assets to Add"
-msgstr "Вибрані активи"
+msgstr "Виберіть доступні активи для додавання"
 
-#, fuzzy
-#| msgid "Asset request has been rejected."
 msgid "Asset request raised for selected categories"
-msgstr "Запит на актив відхилено."
+msgstr "Заявку на актив створено для вибраних категорій"
 
 msgid "Select categories to request, or requests already exist"
-msgstr ""
+msgstr "Виберіть категорії для заявки, або заявки вже існують"
 
-#, fuzzy
-#| msgid "An error occurred: "
 msgid "An error occured"
-msgstr "Сталася помилка: "
+msgstr "Сталася помилка"
 
-#, fuzzy
-#| msgid "No Employees Assigned to Rotating Work Types."
 msgid "Employee assigned to group"
-msgstr "Жодного працівника не призначено на ротаційний тип роботи."
+msgstr "Співробітника призначено до групи"
 
 msgid "Allowance"
 msgstr "Надбавка"
@@ -8788,53 +7932,35 @@ msgstr "Надбавка"
 msgid "Deduction"
 msgstr "Відрахування"
 
-#, fuzzy
-#| msgid "Allowance updated."
 msgid "Allowance excluded"
-msgstr "Надбавку оновлено."
+msgstr "Надбавку виключено"
 
-#, fuzzy
-#| msgid "Added In Rejected Candidates"
 msgid "Added to Selected Allowances"
-msgstr "Додано до відхилених кандидатів"
+msgstr "Додано до вибраних надбавок"
 
-#, fuzzy
-#| msgid "Select All Rows"
 msgid "Select Allowances to Add"
-msgstr "Вибрати всі рядки"
+msgstr "Виберіть надбавки для додавання"
 
-#, fuzzy
-#| msgid "Deduction updated."
 msgid "Deduction excluded"
-msgstr "Утримання оновлено."
+msgstr "Утримання виключено"
 
-#, fuzzy
-#| msgid "Add Deduction"
 msgid "Added to Selected Deductions"
-msgstr "Додати утримання"
+msgstr "Додано до вибраних утримань"
 
-#, fuzzy
-#| msgid "Select Fields to Update"
 msgid "Select Deductions to Add"
-msgstr "Виберіть поля для оновлення"
+msgstr "Виберіть утримання для додавання"
 
-#, fuzzy
-#| msgid "Employee Permission"
 msgid "Employee ID missing."
-msgstr "Дозволи співробітника"
+msgstr "Відсутній ID співробітника."
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Employee found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Співробітників за цим запитом не знайдено."
 
 msgid "Dashboard access provided"
-msgstr ""
+msgstr "Доступ до дашборду надано"
 
-#, fuzzy
-#| msgid "Dashboard Chart Select"
 msgid "Dashboard access removed"
-msgstr "Вибір графіка панелі приладів"
+msgstr "Доступ до дашборду прибрано"
 
 msgid "Action Taken"
 msgstr "Вжитий захід"
@@ -8845,49 +7971,34 @@ msgstr "Дата заходу"
 msgid "Disciplinary Actions"
 msgstr "Дисциплінарні заходи"
 
-#, fuzzy
-#| msgid "Action Date"
 msgid "Action Created"
-msgstr "Дата заходу"
+msgstr "Дію створено"
 
 msgid "Take An Action"
 msgstr "Вжити захід"
 
-#, fuzzy
-#| msgid "Disciplinary action updated."
 msgid "Disciplinary action updated Successfully"
-msgstr "Дисциплінарний захід оновлено."
+msgstr "Дисциплінарну дію успішно оновлено"
 
-#, fuzzy
-#| msgid "Filing status created successfully "
 msgid "Disciplinary action created Successfully"
-msgstr "Статус подання успішно створено "
+msgstr "Дисциплінарну дію успішно створено"
 
-#, fuzzy
-#| msgid "Create document request"
 msgid "Create Document Request"
 msgstr "Створити запит документа"
 
-#, fuzzy
-#| msgid "Document Request"
 msgid "Update Document Request"
-msgstr "Запит документа"
+msgstr "Оновити запит документа"
 
-#, fuzzy
-#| msgid "Document request created successfully"
 msgid "Document Request Updated Successfully"
-msgstr "Запит на документ успішно створено"
+msgstr "Запит документа успішно оновлено"
 
 msgid "Document request created successfully"
 msgstr "Запит на документ успішно створено"
 
-#, fuzzy, python-format
-#| msgid "File type(s) %(ext)s are not allowed."
+#, python-format
 msgid "File type %(ext)s is not allowed."
-msgstr "Типи файлів %(ext)s не дозволені."
+msgstr "Тип файлу %(ext)s не дозволений."
 
-#, fuzzy
-#| msgid "Document uploaded successfully"
 msgid "Document Uploaded Successfully"
 msgstr "Документ успішно завантажено"
 
@@ -8915,10 +8026,8 @@ msgstr "Масово відхилити запити"
 msgid "Document Requests"
 msgstr "Запити документів"
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No employee found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Співробітників за цим запитом не знайдено."
 
 msgid "Send password reset link"
 msgstr "Надіслати посилання для скидання пароля"
@@ -8962,18 +8071,14 @@ msgstr "Журнал пошти"
 msgid "History"
 msgstr "Історія"
 
-#, fuzzy
-#| msgid "Are you sure you want to delete this employee tag ?"
 msgid "Are you sure you want to delete this employee tag?"
 msgstr "Ви впевнені, що хочете видалити цей тег працівника?"
 
 msgid "Employee Tags"
 msgstr "Теги працівників"
 
-#, fuzzy
-#| msgid "Employees Bulk Update"
 msgid "Employee Tag Update"
-msgstr "Масове оновлення співробітників"
+msgstr "Оновлення тега співробітника"
 
 msgid "Revoke Profile Edit Access"
 msgstr "Відкликати доступ до редагування профілю"
@@ -8999,36 +8104,27 @@ msgstr "Список"
 msgid "Card"
 msgstr "Картка"
 
-#, fuzzy, python-format
-#| msgid "Do you want to delete this employee?"
+#, python-format
 msgid "Do you want to %(status)s this employee?"
-msgstr "Бажаєте видалити цього співробітника?"
+msgstr "Ви бажаєте %(status)s цього співробітника?"
 
-#, fuzzy
-#| msgid "Payslip creation date"
 msgid "Policy Creation"
-msgstr "Дата створення розрахункового листка"
+msgstr "Створення політики"
 
-#, fuzzy
-#| msgid "Policy saved"
 msgid "Policy Update"
-msgstr "Політику збережено"
+msgstr "Оновлення політики"
 
 msgid "Policy saved"
 msgstr "Політику збережено"
 
-#, fuzzy
-#| msgid "Policy saved"
 msgid "Policy updated"
-msgstr "Політику збережено"
+msgstr "Політику оновлено"
 
 msgid "Policies"
 msgstr "Політики"
 
-#, fuzzy
-#| msgid "Shift 1"
 msgid "Shift Inbox"
-msgstr "Зміна 1"
+msgstr "Вхідні зміни"
 
 msgid "Search in : Employee"
 msgstr "Пошук у: Співробітник"
@@ -9043,10 +8139,10 @@ msgid "An Employee with this Email already exists"
 msgstr "Співробітник з такою електронною поштою вже існує"
 
 msgid "Badge ID must be unique."
-msgstr ""
+msgstr "Бейдж мусить бути унікальним."
 
 msgid "Badge ID must contain at least one digit."
-msgstr ""
+msgstr "Бейдж мусить містити хоча б одну цифру."
 
 msgid "Create New {} "
 msgstr "Створити новий {}"
@@ -9078,16 +8174,12 @@ msgstr "Ступінь спорідненості контакту для екс
 msgid "Work Phone"
 msgstr "Робочий телефон"
 
-#, fuzzy
-#| msgid "Date of Joining"
 msgid "Date Joining"
-msgstr "Дата прийняття на роботу"
+msgstr "Дата прийому"
 
 msgid "Basic Salary"
 msgstr "Базова заробітна плата"
 
-#, fuzzy
-#| msgid "Salary Per Hour"
 msgid "Salary Hour"
 msgstr "Погодинна оплата"
 
@@ -9109,10 +8201,8 @@ msgstr "Країна банку"
 msgid "Bank State"
 msgstr "Область/штат банку"
 
-#, fuzzy
-#| msgid "Bank Country"
 msgid "Bank City"
-msgstr "Країна банку"
+msgstr "Місто банку"
 
 msgid "Select Fields to Update"
 msgstr "Виберіть поля для оновлення"
@@ -9130,20 +8220,16 @@ msgid "These required headers are missing in the uploaded file: "
 msgstr "У завантаженому файлі відсутні обов'язкові заголовки: "
 
 msgid "Enter a valid phone number (7-20 characters, optional +)."
-msgstr ""
+msgstr "Введіть коректний номер телефону (7–20 символів, можливий +)."
 
-#, fuzzy
-#| msgid "Optional Profile Image"
 msgid "Profile Image"
-msgstr "Необов'язкове фото профілю"
+msgstr "Фото профілю"
 
 msgid "Potential XSS content detected."
 msgstr "Виявлено потенційний вміст XSS."
 
-#, fuzzy
-#| msgid "Is active"
 msgid "Inactive"
-msgstr "Активно"
+msgstr "Неактивно"
 
 msgid "Expected working"
 msgstr "Очікується робота"
@@ -9212,54 +8298,42 @@ msgstr "менше або дорівнює"
 msgid "Use negative numbers to reduce points."
 msgstr "Використовуйте від'ємні числа, щоб зменшити бали."
 
-#, fuzzy
-#| msgid " Import Warning"
 msgid "Warning"
-msgstr " Попередження про імпорт"
+msgstr "Попередження"
 
-#, fuzzy
-#| msgid "Suspended for"
 msgid "Suspension"
-msgstr "Відсторонено на"
+msgstr "Відсторонення"
 
 msgid "Dismissal"
-msgstr ""
+msgstr "Звільнення"
 
 msgid "Action Type"
 msgstr "Тип дії"
 
-#, fuzzy
-#| msgid "Login block"
 msgid "Enable login block :"
-msgstr "Блокування входу"
+msgstr "Увімкнути блокування входу:"
 
 msgid ""
 "If is enabled, employees log in will be blocked based on period of "
 "suspension or dismissal."
 msgstr ""
+"Якщо увімкнено, вхід співробітників блокуватиметься на період відсторонення "
+"або звільнення."
 
 msgid "Action Types"
 msgstr "Типи дій"
 
-#, fuzzy
-#| msgid "Gender Chart"
 msgid "Can view Gender Chart"
-msgstr "Діаграма за статтю"
+msgstr "Може бачити діаграму за статтю"
 
-#, fuzzy
-#| msgid "Department Chart"
 msgid "Can view Department Chart"
-msgstr "Діаграма відділів"
+msgstr "Може бачити діаграму відділів"
 
-#, fuzzy
-#| msgid "Employees Chart"
 msgid "Can view Employees Chart"
-msgstr "Діаграма співробітників"
+msgstr "Може бачити діаграму співробітників"
 
-#, fuzzy
-#| msgid "Can view"
 msgid "Can view Birthdays"
-msgstr "Може переглядати"
+msgstr "Може бачити дні народження"
 
 #, python-format
 msgid "Mail sent to %(employee)s"
@@ -9275,10 +8349,8 @@ msgstr "Політики не знайдено"
 msgid "Policies deleted"
 msgstr "Політики видалено"
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Policy found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Політик за цим запитом не знайдено."
 
 msgid "Attachments added"
 msgstr "Вкладення додано"
@@ -9310,45 +8382,29 @@ msgstr "Політика та дисципліна"
 msgid "Configuration"
 msgstr "Конфігурація"
 
-#, fuzzy
-#| msgid "All\tSettings"
 msgid "All Settings"
 msgstr "Усі\tналаштування"
 
-#, fuzzy
-#| msgid "Allocated Assets"
 msgid "Allocate Asset"
-msgstr "Видані активи"
+msgstr "Видати актив"
 
-#, fuzzy
-#| msgid "Not Returned Assets"
 msgid "Return Asset"
-msgstr "Не повернені активи"
+msgstr "Повернути актив"
 
-#, fuzzy
-#| msgid "Tracking Id"
 msgid "Tracking"
-msgstr "Ідентифікатор відстеження"
+msgstr "Відстеження"
 
-#, fuzzy
-#| msgid "Allocated"
 msgid "Allocate"
-msgstr "Розподілено"
+msgstr "Виділити"
 
-#, fuzzy
-#| msgid "Request User"
 msgid "Request Asset"
-msgstr "Користувач запиту"
+msgstr "Запросити актив"
 
-#, fuzzy
-#| msgid "users in this group"
 msgid "Assign user groups"
-msgstr "користувачів у цій групі"
+msgstr "Призначити групи користувачів"
 
-#, fuzzy
-#| msgid "This employee is not eligible for any allowances."
 msgid "This employee is not assigned to any groups."
-msgstr "Цей працівник не має права на жодні надбавки."
+msgstr "Цей співробітник не призначений до жодної групи."
 
 msgid "Personal Info"
 msgstr "Особиста інформація"
@@ -9356,51 +8412,35 @@ msgstr "Особиста інформація"
 msgid "Bank Info"
 msgstr "Банківська інформація"
 
-#, fuzzy
-#| msgid "Assign Leave"
 msgid "Assign Leave Type"
-msgstr "Призначити відпустку"
+msgstr "Призначити тип відпустки"
 
-#, fuzzy
-#| msgid "All Assigned Leaves"
 msgid "Delete Assigned Leave Type"
-msgstr "Усі призначені відпустки"
+msgstr "Видалити призначений тип відпустки"
 
 msgid "Total Days"
 msgstr "Усього днів"
 
-#, fuzzy
-#| msgid "All time allowance."
 msgid "Allocate Allowance"
-msgstr "Постійна надбавка."
+msgstr "Призначити надбавку"
 
-#, fuzzy
-#| msgid "Remove from sorting"
 msgid "Remove from allowance"
-msgstr "Вилучити із сортування"
+msgstr "Вилучити з надбавки"
 
 msgid "Amount"
 msgstr "Сума"
 
-#, fuzzy
-#| msgid "Allowance & Deduction"
 msgid "Allocate Deduction"
-msgstr "Надбавки та відрахування"
+msgstr "Призначити утримання"
 
-#, fuzzy
-#| msgid "Exclude the deduction"
 msgid "Exclude from deduction"
-msgstr "Виключити утримання"
+msgstr "Виключити з утримання"
 
-#, fuzzy
-#| msgid "In-Active"
 msgid "In-active"
 msgstr "Неактивний"
 
-#, fuzzy
-#| msgid "Dashboard"
 msgid "Dashboard Access"
-msgstr "Дашборд"
+msgstr "Доступ до дашборду"
 
 msgid "Deductions"
 msgstr "Утримання"
@@ -9432,23 +8472,17 @@ msgstr "Запит документа"
 msgid "Document request"
 msgstr "Запит документа"
 
-#, fuzzy
-#| msgid "No documents"
 msgid "No Document"
-msgstr "Немає документів"
+msgstr "Немає документа"
 
-#, fuzzy
-#| msgid "Document"
 msgid "Upload Document"
-msgstr "Документ"
+msgstr "Завантажити документ"
 
 msgid "Are you sure you want to delete this Document Request?"
 msgstr "Ви впевнені, що хочете видалити цей запит документа?"
 
-#, fuzzy
-#| msgid "No comments available at the moment."
 msgid "No Documents available at the moment"
-msgstr "Наразі немає доступних коментарів."
+msgstr "Наразі немає доступних документів"
 
 msgid "file"
 msgstr "файл"
@@ -9456,16 +8490,12 @@ msgstr "файл"
 msgid "Max size of the file"
 msgstr "Максимальний розмір файлу"
 
-#, fuzzy
-#| msgid "No records available at the moment."
 msgid "No records available at the moment"
 msgstr "Наразі немає доступних записів."
 
 msgid "Export Individual Data"
 msgstr "Експорт індивідуальних даних"
 
-#, fuzzy
-#| msgid "Allocation"
 msgid "Allocations"
 msgstr "Розподіл"
 
@@ -9475,10 +8505,8 @@ msgstr "Ви хочете архівувати цього співробітни
 msgid "Do you want to un-archive this employee?"
 msgstr "Ви хочете розархівувати цього співробітника?"
 
-#, fuzzy
-#| msgid "Employee Tags"
 msgid "Employee Tag"
-msgstr "Теги працівників"
+msgstr "Тег співробітника"
 
 msgid "Currently Working"
 msgstr "Наразі працює"
@@ -9498,21 +8526,13 @@ msgstr "Експорт даних"
 msgid "This employee is already related in,"
 msgstr "Цей працівник уже пов’язаний у"
 
-#, fuzzy
-#| msgid ""
-#| " Do you really want to allow this employee to access and log into this "
-#| "webpage?"
 msgid ""
 "Do you really want to prevent this employee from accessing and logging into "
 "this webpage?"
 msgstr ""
-" Ви дійсно хочете дозволити цьому співробітнику доступ і вхід на цю веб-"
+"Ви справді хочете заборонити цьому співробітнику доступ і вхід на цю "
 "сторінку?"
 
-#, fuzzy
-#| msgid ""
-#| " Do you really want to allow this employee to access and log into this "
-#| "webpage?"
 msgid ""
 "Do you really want to allow this employee to access and log into this "
 "webpage?"
@@ -9562,141 +8582,91 @@ msgstr "Завантажити фото"
 msgid "Show"
 msgstr "Показати"
 
-#, fuzzy
-#| msgid "Employee Chart"
 msgid "Employee Dashboard"
-msgstr "Діаграма працівників"
+msgstr "Дашборд співробітника"
 
-#, fuzzy
-#| msgid "Select All Employees"
 msgid "View All Employees"
-msgstr "Вибрати всіх співробітників"
+msgstr "Переглянути всіх співробітників"
 
-#, fuzzy
-#| msgid "Payroll Records"
 msgid "All records"
-msgstr "Записи по заробітній платі"
+msgstr "Усі записи"
 
-#, fuzzy
-#| msgid "Archived Employees"
 msgid "Archived employees"
 msgstr "Архівовані співробітники"
 
-#, fuzzy
-#| msgid "This Month"
 msgid "New This Month"
-msgstr "Цього місяця"
+msgstr "Нові цього місяця"
 
-#, fuzzy
-#| msgid "Projects due in this month"
 msgid "Joined this month"
-msgstr "Проєкти з терміном виконання цього місяця"
+msgstr "Прийняті цього місяця"
 
-#, fuzzy
-#| msgid "Leave days"
 msgid "On Leave Today"
-msgstr "Дні відпустки"
+msgstr "У відпустці сьогодні"
 
-#, fuzzy
-#| msgid "Approved request"
 msgid "Approved leaves"
-msgstr "Затверджений запит"
+msgstr "Затверджені відпустки"
 
-#, fuzzy
-#| msgid "Department"
 msgid "By Department"
-msgstr "Відділ"
+msgstr "За відділом"
 
-#, fuzzy
-#| msgid "Name of the department"
 msgid "Active headcount per department"
-msgstr "Назва кафедри"
+msgstr "Активна чисельність за відділами"
 
-#, fuzzy
-#| msgid "Contributions"
 msgid "Gender Distribution"
-msgstr "Внески"
+msgstr "Розподіл за статтю"
 
-#, fuzzy
-#| msgid "Active Employees"
 msgid "Active employees by gender"
-msgstr "Активні працівники"
+msgstr "Активні співробітники за статтю"
 
-#, fuzzy
-#| msgid "Active Employees"
 msgid "Active employees by type"
-msgstr "Активні працівники"
+msgstr "Активні співробітники за типом"
 
-#, fuzzy
-#| msgid "Job Position"
 msgid "By Job Position"
-msgstr "Посада"
+msgstr "За посадою"
 
-#, fuzzy
-#| msgid "Job position"
 msgid "Top 10 positions"
-msgstr "Посада"
+msgstr "Топ-10 посад"
 
-#, fuzzy
-#| msgid "Monthly"
 msgid "Monthly Joinings"
-msgstr "Щомісяця"
+msgstr "Прийоми за місяцями"
 
 msgid "New hires over the last 6 months"
-msgstr ""
+msgstr "Нові співробітники за останні 6 місяців"
 
-#, fuzzy
-#| msgid "Replace Employee"
 msgid "Recent Employees"
-msgstr "Замінити співробітника"
+msgstr "Останні співробітники"
 
-#, fuzzy
-#| msgid "Upcoming holidays"
 msgid "Upcoming Birthdays"
-msgstr "Найближчі свята"
+msgstr "Найближчі дні народження"
 
-#, fuzzy
-#| msgid "department"
 msgid "No department data"
-msgstr "відділ"
+msgstr "Немає даних про відділи"
 
-#, fuzzy
-#| msgid "Auto generate"
 msgid "No gender data"
-msgstr "Автогенерація"
+msgstr "Немає даних про стать"
 
-#, fuzzy
-#| msgid "Work type updated."
 msgid "No type data"
-msgstr "Тип роботи оновлено."
+msgstr "Немає даних про типи"
 
-#, fuzzy
-#| msgid "Job position updated."
 msgid "No position data"
-msgstr "Посаду оновлено."
+msgstr "Немає даних про посади"
 
-#, fuzzy
-#| msgid "New Projects"
 msgid "New Hires"
-msgstr "Нові проєкти"
+msgstr "Нові співробітники"
 
-#, fuzzy
-#| msgid "To employee "
 msgid "No employees"
-msgstr "На співробітника "
+msgstr "Немає співробітників"
 
 #, python-brace-format
 msgid "${emp.name}"
-msgstr ""
+msgstr "${emp.name}"
 
-#, fuzzy
-#| msgid "Upcoming holidays"
 msgid "No upcoming birthdays"
-msgstr "Найближчі свята"
+msgstr "Немає найближчих днів народження"
 
 #, python-brace-format
 msgid "${b.name}"
-msgstr ""
+msgstr "${b.name}"
 
 msgid "Tomorrow"
 msgstr "Завтра"
@@ -9785,20 +8755,14 @@ msgstr "Інші вкладення"
 msgid "---Choose Job Role---"
 msgstr "---Виберіть посаду---"
 
-#, fuzzy
-#| msgid "employee-profile"
 msgid "Employee Profile"
 msgstr "employee-profile"
 
-#, fuzzy
-#| msgid "Employee Details"
 msgid "Employee Detail View"
-msgstr "Дані співробітника"
+msgstr "Детальний перегляд співробітника"
 
-#, fuzzy
-#| msgid "Group Assign"
 msgid "Employee Group Assign"
-msgstr "Призначення групи"
+msgstr "Призначення групи співробітнику"
 
 msgid "for:"
 msgstr "для:"
@@ -9891,12 +8855,10 @@ msgid "Answer view"
 msgstr "Перегляд відповіді"
 
 msgid "copy outline"
-msgstr ""
+msgstr "copy outline"
 
-#, fuzzy
-#| msgid "Do you want to delete this project?"
 msgid "Do you want to delete this policy?"
-msgstr "Бажаєте видалити цей проєкт?"
+msgstr "Ви бажаєте видалити цю політику?"
 
 msgid "View policy"
 msgstr "Переглянути політику"
@@ -9920,6 +8882,8 @@ msgid ""
 "Define the unit values used when employees redeem bonus points or leave as "
 "encashment."
 msgstr ""
+"Визначте значення одиниць при обміні бонусних балів або відпустки на "
+"компенсацію."
 
 msgid "Bonus Unit"
 msgstr "Одиниця бонусу"
@@ -9927,11 +8891,11 @@ msgstr "Одиниця бонусу"
 msgid "Set the amount for one bonus points encashment (unit)"
 msgstr "Встановіть суму для обміну одного бонусного бала на гроші (одиниця)"
 
-#, fuzzy
-#| msgid "Set the amount for one bonus points encashment (unit)"
 msgid ""
 "Set the amount credited for each bonus point when redeemed as encashment."
-msgstr "Встановіть суму для обміну одного бонусного бала на гроші (одиниця)"
+msgstr ""
+"Задайте суму, що зараховується за кожен бонусний бал при обміні на "
+"компенсацію."
 
 msgid "Leave Unit"
 msgstr "Одиниця відпустки"
@@ -9940,12 +8904,11 @@ msgid "Set the amout for one leave encashment"
 msgstr ""
 "Встановіть суму для обміну одного дня відпустки на грошову компенсацію"
 
-#, fuzzy
-#| msgid "Set the amout for one leave encashment"
 msgid ""
 "Set the amount credited for each unit of leave when redeemed as encashment."
 msgstr ""
-"Встановіть суму для обміну одного дня відпустки на грошову компенсацію"
+"Задайте суму, що зараховується за кожну одиницю відпустки при обміні на "
+"компенсацію."
 
 msgid "Badge Prefix"
 msgstr "Префікс бейджа"
@@ -10039,7 +9002,7 @@ msgid "Add points"
 msgstr "Додати бали"
 
 msgid "ellipsis vertical"
-msgstr ""
+msgstr "ellipsis vertical"
 
 msgid "Balance points to redeem:"
 msgstr "Балансові бали для обміну:"
@@ -10116,15 +9079,11 @@ msgstr "Причина"
 msgid "Upload file"
 msgstr "Завантажити файл"
 
-#, fuzzy
-#| msgid "Are you not available for this shift reallocation?"
 msgid "Preview not available for this file type."
-msgstr "Ви недоступні для цього перерозподілу зміни?"
+msgstr "Перегляд недоступний для цього типу файлу."
 
-#, fuzzy
-#| msgid "Download Error File"
 msgid "Download File"
-msgstr "Завантажити файл з помилками"
+msgstr "Завантажити файл"
 
 msgid "File Preview"
 msgstr "Попередній перегляд файлу"
@@ -10190,7 +9149,7 @@ msgid "Create asset request"
 msgstr "Створити запит на актив"
 
 msgid "add sharp"
-msgstr ""
+msgstr "add sharp"
 
 msgid "New attendance request"
 msgstr "Новий запит на відвідуваність"
@@ -10452,18 +9411,14 @@ msgstr "Неактивний"
 msgid "No Data Found..."
 msgstr "Дані не знайдено..."
 
-#, fuzzy
-#| msgid "Invalid Request"
 msgid "Invalid page number"
-msgstr "Недійсний запит"
+msgstr "Невірний номер сторінки"
 
 msgid "Note added successfully.."
 msgstr "Нотатку успішно додано.."
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Employee Note found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Нотаток співробітника за цим запитом не знайдено."
 
 msgid "Note updated successfully..."
 msgstr "Нотатку успішно оновлено..."
@@ -10471,10 +9426,8 @@ msgstr "Нотатку успішно оновлено..."
 msgid "Note deleted successfully."
 msgstr "Нотатку успішно видалено."
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Bonus Point found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Бонусних балів за цим запитом не знайдено."
 
 msgid "Added {} points to the bonus account"
 msgstr "Додано {} балів на бонусний рахунок"
@@ -10512,10 +9465,8 @@ msgstr "Конфігурацію розпізнавання обличчя ус�
 msgid "Not valid"
 msgstr "Не діє"
 
-#, fuzzy
-#| msgid "Face recognition enabled successfully"
 msgid "Face detection {} successfully"
-msgstr "Розпізнавання обличчя успішно увімкнено"
+msgstr "Розпізнавання обличчя {} успішно"
 
 msgid "Geofence Configuration"
 msgstr "Налаштування геозони"
@@ -10541,20 +9492,14 @@ msgstr "Конфігурацію геозонування успішно ств�
 msgid "Are you sure you want to remove this department manager?"
 msgstr "Ви впевнені, що хочете видалити цього керівника відділу?"
 
-#, fuzzy
-#| msgid "Department Managers"
 msgid "Department managers"
 msgstr "Керівники відділів"
 
-#, fuzzy
-#| msgid "Department Manager"
 msgid "Create department manager"
-msgstr "Керівник відділу"
+msgstr "Створити керівника відділу"
 
-#, fuzzy
-#| msgid "Department Manager"
 msgid "Update department manager"
-msgstr "Керівник відділу"
+msgstr "Оновити керівника відділу"
 
 msgid "The department manager updated successfully."
 msgstr "Менеджера відділу успішно оновлено."
@@ -10562,15 +9507,11 @@ msgstr "Менеджера відділу успішно оновлено."
 msgid "The department manager created successfully."
 msgstr "Менеджера відділу успішно створено."
 
-#, fuzzy
-#| msgid "FAQ Category"
 msgid "FAQ category Create"
-msgstr "Категорія FAQ"
+msgstr "Створити категорію FAQ"
 
-#, fuzzy
-#| msgid "FAQ Category"
 msgid "FAQ category Update"
-msgstr "Категорія FAQ"
+msgstr "Оновити категорію FAQ"
 
 msgid "The FAQ category updated successfully."
 msgstr "Категорію FAQ успішно оновлено."
@@ -10578,15 +9519,11 @@ msgstr "Категорію FAQ успішно оновлено."
 msgid "The FAQ Category created successfully."
 msgstr "Категорію FAQ успішно створено."
 
-#, fuzzy
-#| msgid "Create"
 msgid "FAQ Create"
-msgstr "Створити"
+msgstr "Створити FAQ"
 
-#, fuzzy
-#| msgid "Update"
 msgid "FAQ Update"
-msgstr "Оновити"
+msgstr "Оновити FAQ"
 
 msgid "The FAQ updated successfully."
 msgstr "FAQ успішно оновлено."
@@ -10603,10 +9540,8 @@ msgstr "Власник"
 msgid "Priority"
 msgstr "Пріоритет"
 
-#, fuzzy
-#| msgid "Assign"
 msgid "Assigner"
-msgstr "Призначити"
+msgstr "Хто призначив"
 
 msgid "Unarchive"
 msgstr "Розархівувати"
@@ -10647,8 +9582,6 @@ msgstr "Керівники відділів"
 msgid "Helpdesk Tags"
 msgstr "Теги служби підтримки"
 
-#, fuzzy
-#| msgid "Are you sure you want to delete this tag ?"
 msgid "Are you sure you want to delete this tag?"
 msgstr "Ви впевнені, що хочете видалити цей тег?"
 
@@ -10673,15 +9606,11 @@ msgstr "Заявку успішно оновлено."
 msgid "Sorry, something went wrong!"
 msgstr "Вибачте, щось пішло не так!"
 
-#, fuzzy
-#| msgid "User instance with this mail already exists"
 msgid "Ticket type with this title already exists."
-msgstr "Примірник користувача з цією поштою вже існує"
+msgstr "Тип заявки з такою назвою вже існує."
 
-#, fuzzy
-#| msgid "An employee with this email already exists"
 msgid "Ticket type with this prefix already exists."
-msgstr "Співробітник із цією електронною адресою вже існує"
+msgstr "Тип заявки з таким префіксом вже існує."
 
 msgid "Deadline should be greater than today"
 msgstr "Кінцевий термін має бути пізніше сьогоднішньої дати"
@@ -10725,16 +9654,14 @@ msgstr "Переспрямувати до"
 msgid "Ticket"
 msgstr "Заявка"
 
-#, fuzzy
-#| msgid "today"
 msgid "Due today"
-msgstr "сьогодні"
+msgstr "дедлайн сьогодні"
 
 msgid "Overdue by {} days"
-msgstr ""
+msgstr "Прострочено на {} днів"
 
 msgid "Due in {} days"
-msgstr ""
+msgstr "Дедлайн через {} днів"
 
 msgid "FAQ Category"
 msgstr "Категорія FAQ"
@@ -10753,12 +9680,13 @@ msgstr "Служба підтримки"
 
 msgid "Assign managers responsible for helpdesk tickets per department."
 msgstr ""
+"Призначте менеджерів, відповідальних за заявки служби підтримки по відділах."
 
 msgid "Create tags for classifying helpdesk tickets."
-msgstr ""
+msgstr "Створіть теги для класифікації заявок служби підтримки."
 
 msgid "Define categories of helpdesk tickets."
-msgstr ""
+msgstr "Визначте категорії заявок служби підтримки."
 
 msgid "Claim Requests"
 msgstr "Запити на компенсацію"
@@ -10775,162 +9703,110 @@ msgstr "archive sharp"
 msgid "Till date"
 msgstr "До дати"
 
-#, fuzzy
-#| msgid "Helpdesk Tags"
 msgid "Helpdesk Dashboard"
-msgstr "Теги служби підтримки"
+msgstr "Дашборд служби підтримки"
 
-#, fuzzy
-#| msgid "pipeline"
 msgid "Pipeline View"
-msgstr "воронка підбору"
+msgstr "Воронка підбору"
 
-#, fuzzy
-#| msgid "Task Status"
 msgid "Ticket Status"
-msgstr "Статус завдання"
+msgstr "Статус заявки"
 
-#, fuzzy
-#| msgid "All Tickets"
 msgid "All active tickets"
-msgstr "Усі заявки"
+msgstr "Усі активні заявки"
 
-#, fuzzy
-#| msgid "Start Date Breakdown"
 msgid "Priority Breakdown"
-msgstr "Розбивка початкової дати"
+msgstr "Розбивка за пріоритетом"
 
 msgid "Low, medium, high"
-msgstr ""
+msgstr "Низький, середній, високий"
 
-#, fuzzy
-#| msgid "Ticket Type"
 msgid "Tickets by Type"
-msgstr "Тип заявки"
+msgstr "Заявки за типом"
 
-#, fuzzy
-#| msgid "Questions not answered yet."
 msgid "Suggestion, complaint, service, etc."
-msgstr "Питання без відповіді."
+msgstr "Пропозиція, скарга, послуга тощо."
 
-#, fuzzy
-#| msgid "Same Department"
 msgid "Tickets by Department"
-msgstr "Той самий відділ"
+msgstr "Заявки за відділами"
 
-#, fuzzy
-#| msgid "Same Department"
 msgid "Raised by department"
-msgstr "Той самий відділ"
+msgstr "Створено за відділами"
 
-#, fuzzy
-#| msgid "Ticket Type"
 msgid "Ticket Trend"
-msgstr "Тип заявки"
+msgstr "Тенденція заявок"
 
 msgid "Created vs resolved — last 6 months"
-msgstr ""
+msgstr "Створено та вирішено — останні 6 місяців"
 
-#, fuzzy
-#| msgid "All Company"
 msgid "SLA Compliance"
-msgstr "Усі компанії"
+msgstr "Дотримання SLA"
 
 msgid "Resolved within deadline"
-msgstr ""
+msgstr "Вирішено в межах дедлайну"
 
-#, fuzzy
-#| msgid "Assigned To"
 msgid "Assignee Workload"
-msgstr "Призначено"
+msgstr "Навантаження виконавця"
 
 msgid "Open tickets per assignee"
-msgstr ""
+msgstr "Відкриті заявки на виконавця"
 
-#, fuzzy
-#| msgid "Add Tickets"
 msgid "Overdue Tickets"
-msgstr "Додати заявки"
+msgstr "Прострочені заявки"
 
-#, fuzzy
-#| msgid "Selected Tickets"
 msgid "Recent Tickets"
-msgstr "Вибрані заявки"
+msgstr "Останні заявки"
 
-#, fuzzy
-#| msgid "Tickets"
 msgid "Open Tickets"
-msgstr "Заявки"
+msgstr "Відкриті заявки"
 
-#, fuzzy
-#| msgid "New"
 msgid "new"
 msgstr "Нова"
 
-#, fuzzy
-#| msgid "In progress"
 msgid "in progress"
 msgstr "В процесі"
 
-#, fuzzy
-#| msgid "Conversion Rate"
 msgid "Resolution Rate"
-msgstr "Коефіцієнт конверсії"
+msgstr "Рівень вирішення"
 
-#, fuzzy
-#| msgid "Resolved"
 msgid "resolved of"
-msgstr "Вирішено"
+msgstr "вирішено з"
 
-#, fuzzy
-#| msgid "Overtime"
 msgid "Overdue"
-msgstr "Понаднормові"
+msgstr "Прострочено"
 
 msgid "on hold"
-msgstr ""
+msgstr "на паузі"
 
-#, fuzzy
-#| msgid "Deadline"
 msgid "Past deadline"
-msgstr "Кінцевий термін"
+msgstr "Прострочено"
 
-#, fuzzy
-#| msgid "Add Question"
 msgid "Avg Resolution"
-msgstr "Додати питання"
+msgstr "Сер. час вирішення"
 
 msgid "claims pending"
-msgstr ""
+msgstr "компенсації в очікуванні"
 
-#, fuzzy
-#| msgid "days to encash."
 msgid "Days to resolve"
-msgstr "днів для компенсації."
+msgstr "Днів на вирішення"
 
-#, fuzzy
-#| msgid "Tickets"
 msgid "No tickets"
-msgstr "Заявки"
+msgstr "Немає заявок"
 
 msgid "No tickets with deadlines"
-msgstr ""
+msgstr "Немає заявок з дедлайнами"
 
-#, fuzzy
-#| msgid "Invalid time"
 msgid "on time"
-msgstr "Невірний час"
+msgstr "вчасно"
 
 msgid "overdue"
-msgstr ""
+msgstr "прострочено"
 
-#, fuzzy
-#| msgid "Jane assigned ticket to"
 msgid "No assigned tickets"
-msgstr "Jane призначила заявку для"
+msgstr "Немає призначених заявок"
 
 msgid "No overdue tickets"
-msgstr ""
+msgstr "Немає прострочених заявок"
 
 msgid "Are you sure you want to delete this FAQ Category?"
 msgstr "Ви впевнені, що хочете видалити цю категорію FAQ?"
@@ -10993,7 +9869,7 @@ msgid "There are no claim requests at the moment."
 msgstr "Наразі немає жодного запиту на компенсацію."
 
 msgid "oh-link--secondary"
-msgstr ""
+msgstr "oh-link--secondary"
 
 msgid "Created the ticket "
 msgstr "Створив(ла) заявку "
@@ -11043,15 +9919,11 @@ msgstr "Завантаження файлу"
 msgid "Delete attachment"
 msgstr "Видалити вкладення"
 
-#, fuzzy
-#| msgid "Are you sure do you want to delete this file ?"
 msgid "Are you sure you want to delete this file?"
 msgstr "Ви впевнені, що хочете видалити цей файл?"
 
-#, fuzzy
-#| msgid "Something went wrong while updating."
 msgid "Something went wrong, the status was not updated."
-msgstr "Під час оновлення сталася помилка."
+msgstr "Щось пішло не так, статус не оновлено."
 
 msgid "Ticket Id"
 msgstr "ID заявки"
@@ -11081,10 +9953,8 @@ msgstr "Пошта не надіслана на %(employee)s"
 msgid "The FAQ category has been deleted successfully."
 msgstr "Категорію FAQ успішно видалено."
 
-#, fuzzy
-#| msgid "No Attachment found matching the query."
 msgid "No FAQ category found matching the query."
-msgstr "Вкладень, що відповідають запиту, не знайдено."
+msgstr "Категорій FAQ за цим запитом не знайдено."
 
 msgid "You cannot delete this FAQ category."
 msgstr "Ви не можете видалити цю категорію FAQ."
@@ -11095,18 +9965,14 @@ msgstr "Для вказаної категорії FAQ не знайдено."
 msgid "The FAQ \"{}\" has been deleted successfully."
 msgstr "FAQ \"{}\" успішно видалено."
 
-#, fuzzy
-#| msgid "No Attachment found matching the query."
 msgid "No FAQ found matching the query."
-msgstr "Вкладень, що відповідають запиту, не знайдено."
+msgstr "FAQ за цим запитом не знайдено."
 
 msgid "You cannot delete this FAQ."
 msgstr "Ви не можете видалити цей FAQ."
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Ticket found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Заявок за цим запитом не знайдено."
 
 msgid "The Ticket un-archived successfully."
 msgstr "Заявку успішно розархівовано."
@@ -11114,10 +9980,8 @@ msgstr "Заявку успішно розархівовано."
 msgid "The Ticket archived successfully."
 msgstr "Заявку успішно заархівовано."
 
-#, fuzzy
-#| msgid "Invalid request"
 msgid "Invalid request method."
-msgstr "Недійсний запит"
+msgstr "Невірний метод запиту."
 
 msgid "The Ticket status updated successfully."
 msgstr "Статус заявки успішно оновлено."
@@ -11186,10 +10050,8 @@ msgstr "Заявку на компенсацію успішно затвердж
 msgid "Claim request rejected successfully."
 msgstr "Заявку на компенсацію відхилено."
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Department Manager found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Керівників відділів за цим запитом не знайдено."
 
 msgid "The department manager has been deleted successfully"
 msgstr "Менеджера відділу успішно видалено"
@@ -11200,23 +10062,17 @@ msgstr "Пріоритет успішно оновлено."
 msgid "Ticket type has been deleted successfully!"
 msgstr "Тип заявки успішно видалено!"
 
-#, fuzzy
-#| msgid "Ticket type not found"
 msgid "Ticket type can not delete"
-msgstr "Тип заявки не знайдено"
+msgstr "Тип заявки не можна видалити"
 
-#, fuzzy, python-format
-#| msgid "Question created successfully."
+#, python-format
 msgid "Automation '%(faq_obj_question)s' created successfully."
-msgstr "Запитання успішно створено."
+msgstr "Автоматизацію '%(faq_obj_question)s' успішно створено."
 
-#, fuzzy, python-format
-#| msgid "Compensatory Leave Request already exists."
+#, python-format
 msgid "Automation '%(faq_obj_question)s' already exists."
-msgstr "Заявка на компенсаційну відпустку вже існує."
+msgstr "Автоматизація '%(faq_obj_question)s' вже існує."
 
-#, fuzzy
-#| msgid "Files uploaded successfully"
 msgid "File(s) uploaded successfully."
 msgstr "Файли успішно завантажено"
 
@@ -11260,54 +10116,37 @@ msgstr "Для цього діапазону дат уже є запит на в
 msgid "There is a mismatch in the breakdown of the start date and end date."
 msgstr "Існує невідповідність у розподілі дати початку та дати завершення."
 
-#, fuzzy
-#| msgid "No employees have taken leave today."
 msgid "Employee doesn't have enough leave days.."
-msgstr "Сьогодні жоден співробітник не брав відпустку."
+msgstr "У співробітника недостатньо днів відпустки."
 
 msgid "Nothing to approve."
 msgstr "Нічого для схвалення."
 
 msgid "If 'is_fixed' is True, 'amount' must be a positive number."
-msgstr ""
+msgstr "Якщо 'is_fixed' — True, 'amount' мусить бути додатним числом."
 
-#, fuzzy
-#| msgid ""
-#| "If the 'Is fixed' field is disabled, the 'Based on' field is required."
 msgid "If 'is_fixed' is False, 'based_on' is required."
-msgstr "Якщо поле «Фіксована» вимкнено, поле «На основі» є обов'язковим."
+msgstr "Якщо 'is_fixed' — False, потрібне 'based_on'."
 
-#, fuzzy
-#| msgid ""
-#| "If based on is attendance,                         then per attendance fixed"
-#| " amount must be filled."
 msgid ""
 "If 'based_on' is 'attendance', 'per_attendance_fixed_amount' is required."
 msgstr ""
-"Якщо основою є присутність, необхідно заповнити фіксовану суму за "
-"присутність."
+"Якщо 'based_on' — 'attendance', потрібне 'per_attendance_fixed_amount'."
 
-#, fuzzy
-#| msgid "If based on is shift, then shift must be filled."
 msgid "If 'based_on' is 'shift_id', 'shift_id' is required."
-msgstr "Якщо основою є зміна, зміна має бути заповнена."
+msgstr "Якщо 'based_on' — 'shift_id', потрібне 'shift_id'."
 
-#, fuzzy
-#| msgid "If based on is work type, then work type must be filled."
 msgid "If 'based_on' is 'work_type_id', 'work_type_id' is required."
-msgstr "Якщо основою є тип роботи, тип роботи має бути заповнений."
+msgstr "Якщо 'based_on' — 'work_type_id', потрібне 'work_type_id'."
 
-#, fuzzy
-#| msgid ""
-#| "If condition based, all fields (field, value, condition) must be filled."
 msgid ""
 "If 'is_condition_based' is True, 'field', 'value', and 'condition' are "
 "required."
 msgstr ""
-"Якщо на основі умови, всі поля (поле, значення, умова) мають бути заповнені."
+"Якщо 'is_condition_based' — True, потрібні 'field', 'value' і 'condition'."
 
 msgid "If 'has_max_limit' is True, 'maximum_amount' is required."
-msgstr ""
+msgstr "Якщо 'has_max_limit' — True, потрібне 'maximum_amount'."
 
 msgid "Nothing to reject."
 msgstr "Нічого відхилити."
@@ -11327,15 +10166,11 @@ msgstr "Ви впевнені, що хочете видалити цей тег 
 msgid "History Tags"
 msgstr "Теги історії"
 
-#, fuzzy
-#| msgid "Create Tag"
 msgid "Create Audit Tag"
-msgstr "Створити тег"
+msgstr "Створити тег аудиту"
 
-#, fuzzy
-#| msgid "History Tag Update"
 msgid "Audit Tag Update"
-msgstr "Оновлення тега історії"
+msgstr "Оновлення тега аудиту"
 
 msgid "Updation title"
 msgstr "Заголовок оновлення"
@@ -11350,58 +10185,43 @@ msgid "Updation tag"
 msgstr "Тег оновлення"
 
 msgid "default"
-msgstr ""
+msgstr "за замовчуванням"
 
 msgid ""
 "Select the models whose changes should be recorded in the audit log. If no "
 "models are selected, the built-in defaults (Employee, "
 "EmployeeWorkInformation, EmployeeBankDetails) are used."
 msgstr ""
+"Виберіть моделі, зміни яких слід фіксувати в журналі аудиту. Якщо моделі не "
+"вибрано, використовуються вбудовані типові (Employee, "
+"EmployeeWorkInformation, EmployeeBankDetails)."
 
-#, fuzzy
-#| msgid "Tracking Fields"
 msgid "Tracked Fields"
-msgstr "Поля відстеження"
+msgstr "Відстежувані поля"
 
-#, fuzzy
-#| msgid "Leave type has already been assigned to the employee."
 msgid "Leave empty to track every field on the model."
-msgstr "Цей тип відпустки вже призначено співробітнику."
+msgstr "Залиште порожнім, щоб відстежувати всі поля моделі."
 
-#, fuzzy
-#| msgid "Objective not found."
 msgid "Object not found"
-msgstr "Ціль не знайдено."
+msgstr "Об'єкт не знайдено"
 
-#, fuzzy
-#| msgid "Apply"
 msgid "App"
-msgstr "Застосувати"
+msgstr "Застосунок"
 
-#, fuzzy
-#| msgid "Model name"
 msgid "Model"
-msgstr "Назва моделі"
+msgstr "Модель"
 
-#, fuzzy
-#| msgid "Enable"
 msgid "Enabled"
-msgstr "Увімкнути"
+msgstr "Увімкнено"
 
-#, fuzzy
-#| msgid "Facedetection Configuration"
 msgid "Audit Tracking Configuration"
-msgstr "Налаштування розпізнавання обличчя"
+msgstr "Налаштування аудиту"
 
-#, fuzzy
-#| msgid "Facedetection Configuration"
 msgid "Audit Tracking Configurations"
-msgstr "Налаштування розпізнавання обличчя"
+msgstr "Налаштування аудиту"
 
-#, fuzzy
-#| msgid "Add Field"
 msgid "Audit Fields"
-msgstr "Додати поле"
+msgstr "Поля аудиту"
 
 #, python-format
 msgid ""
@@ -11411,11 +10231,14 @@ msgid ""
 "                track every field.\n"
 "            "
 msgstr ""
+"\n"
+"                Виберіть поля <strong>%(app_label)s.%(model_name)s</strong>,\n"
+"                які слід фіксувати в журналі аудиту. Залиште список порожнім, щоб\n"
+"                відстежувати всі поля.\n"
+"            "
 
-#, fuzzy
-#| msgid "Save filter"
 msgid "Save Fields"
-msgstr "Зберегти фільтр"
+msgstr "Зберегти поля"
 
 msgid ""
 "\n"
@@ -11424,19 +10247,19 @@ msgid ""
 "                Bank Details) are always tracked and cannot be removed.\n"
 "            "
 msgstr ""
+"\n"
+"                Виберіть, які моделі повинні фіксувати свої зміни в журналі аудиту.\n"
+"                Типові моделі (Співробітник, Робоча інформація співробітника, Банківські\n"
+"                реквізити співробітника) відстежуються завжди й не можуть бути вилучені."
 
 msgid "Per-model Field Selection"
-msgstr ""
+msgstr "Вибір полів для кожної моделі"
 
-#, fuzzy
-#| msgid "All Tickets"
 msgid "All fields"
-msgstr "Усі заявки"
+msgstr "Усі поля"
 
-#, fuzzy
-#| msgid "Add Field"
 msgid "Edit Fields"
-msgstr "Додати поле"
+msgstr "Редагувати поля"
 
 msgid "Horilla Bot"
 msgstr "Horilla Bot"
@@ -11444,42 +10267,30 @@ msgstr "Horilla Bot"
 msgid "Why this change?"
 msgstr "Чому ця зміна?"
 
-#, fuzzy
-#| msgid "Default pagination updated."
 msgid "Audit tracking configuration updated."
-msgstr "Пагінацію за замовчуванням оновлено."
+msgstr "Налаштування аудиту оновлено."
 
 #, python-format
 msgid "Tracked fields updated for %(model)s."
-msgstr ""
+msgstr "Відстежувані поля оновлено для %(model)s."
 
-#, fuzzy
-#| msgid "Horilla Bot"
 msgid "Horilla Auth"
-msgstr "Horilla Bot"
+msgstr "Horilla Auth"
 
-#, fuzzy
-#| msgid "User"
 msgid "Users"
-msgstr "Користувач"
+msgstr "Користувачі"
 
-#, fuzzy
-#| msgid "Load Automations"
 msgid "Automations"
-msgstr "Завантажити автоматизації"
+msgstr "Автоматизації"
 
-#, fuzzy
-#| msgid "Also send to"
 msgid "Also Sent to"
-msgstr "Також надіслати"
+msgstr "Також надіслано"
 
 msgid "The employees selected here will receive the email as Cc."
 msgstr "Обрані тут співробітники отримають лист у копії (Cc)."
 
-#, fuzzy
-#| msgid "Mail Log"
 msgid "Mail To"
-msgstr "Журнал пошти"
+msgstr "Кому"
 
 msgid ""
 "Fill mail template details (receiver/instance, `self` will be the person who"
@@ -11488,76 +10299,48 @@ msgstr ""
 "Заповніть деталі шаблону листа (одержувач/екземпляр, `self` — особа, яка "
 "запускає автоматизацію)"
 
-#, fuzzy
-#| msgid "Bank Details"
 msgid "Mail Details"
-msgstr "Банківські реквізити"
+msgstr "Деталі листа"
 
-#, fuzzy
-#| msgid "Create"
 msgid "On Create"
-msgstr "Створити"
+msgstr "При створенні"
 
-#, fuzzy
-#| msgid "Update"
 msgid "On Update"
-msgstr "Оновити"
+msgstr "При оновленні"
 
-#, fuzzy
-#| msgid "Delete"
 msgid "On Delete"
-msgstr "Видалити"
+msgstr "При видаленні"
 
-#, fuzzy
-#| msgid "Send Email"
 msgid "Send as Email"
-msgstr "Надіслати лист"
+msgstr "Надіслати як лист"
 
-#, fuzzy
-#| msgid "Notification"
 msgid "Send as Notification"
-msgstr "Сповіщення"
+msgstr "Надіслати як сповіщення"
 
-#, fuzzy
-#| msgid "Send via Email Notification or Both"
 msgid "Send as Email and Notification"
-msgstr "Надіслати сповіщення електронною поштою або обидва"
+msgstr "Надіслати як лист і сповіщення"
 
-#, fuzzy
-#| msgid "Mail Not Sent"
 msgid "Mail to/Notify to"
-msgstr "Лист не надіслано"
+msgstr "Кому надіслати/повідомити"
 
-#, fuzzy
-#| msgid ""
-#| "Fill mail template details (receiver/instance, `self` will be the person who"
-#| " triggers the automation)"
 msgid ""
 "Fill mail template details(reciever/instance, `self` will be the person who "
 "trigger the automation)"
 msgstr ""
-"Заповніть деталі шаблону листа (одержувач/екземпляр, `self` — особа, яка "
-"запускає автоматизацію)"
+"Заповніть деталі шаблону листа (отримувач/екземпляр, `self` — це той, хто "
+"запустив автоматизацію)"
 
-#, fuzzy
-#| msgid "Mail Templates"
 msgid "Mail Template"
-msgstr "Шаблони листів"
+msgstr "Шаблон листа"
 
-#, fuzzy
-#| msgid "Also send to"
 msgid "Also Send to"
 msgstr "Також надіслати"
 
-#, fuzzy
-#| msgid "Delivery Channel"
 msgid "Choose Delivery Channel"
-msgstr "Канал доставки"
+msgstr "Виберіть канал доставки"
 
-#, fuzzy
-#| msgid "Template as Attachments"
 msgid "Template Attachments"
-msgstr "Шаблон як вкладення"
+msgstr "Вкладення шаблону"
 
 msgid "Load Automations"
 msgstr "Завантажити автоматизації"
@@ -11565,51 +10348,38 @@ msgstr "Завантажити автоматизації"
 msgid "Notification"
 msgstr "Сповіщення"
 
-#, fuzzy
-#| msgid "Trigger automated emails on model events"
 msgid ""
 "Configure automated email triggers based on model events and conditions."
-msgstr "Активувати автоматичні електронні листи про події моделі"
+msgstr "Налаштуйте автоматичні email-тригери на основі подій моделей та умов."
 
 msgid "Not Added"
 msgstr "Не додано"
 
-#, fuzzy
-#| msgid "Load Automations"
 msgid "Refresh Automations"
-msgstr "Завантажити автоматизації"
+msgstr "Оновити автоматизації"
 
-#, fuzzy
-#| msgid "Load Automations"
 msgid "New Automation"
-msgstr "Завантажити автоматизації"
+msgstr "Нова автоматизація"
 
-#, fuzzy
-#| msgid "Asset View"
 msgid "Detailed View"
-msgstr "Перегляд активів"
+msgstr "Детальний перегляд"
 
-#, fuzzy
-#| msgid "Mail"
 msgid "Mail Cc"
-msgstr "Пошта"
+msgstr "Копія (Cc)"
 
 msgid "Trigger"
-msgstr ""
+msgstr "Тригер"
 
-#, fuzzy, python-format
-#| msgid "Automations refreshed successfully."
+#, python-format
 msgid "Automation '%(automation_obj_title)s' added successfully."
-msgstr "Автоматизацію успішно оновлено."
+msgstr "Автоматизацію '%(automation_obj_title)s' успішно додано."
 
 #, python-format
 msgid "Automation '%(automation_obj_title)s' already exists."
-msgstr ""
+msgstr "Автоматизація '%(automation_obj_title)s' вже існує."
 
-#, fuzzy
-#| msgid "No history found."
 msgid "No matching query found."
-msgstr "Історію не знайдено."
+msgstr "Відповідного запису не знайдено."
 
 msgid "Automation deleted"
 msgstr "Автоматику видалено"
@@ -11707,359 +10477,310 @@ msgstr "Автоматичне резервне копіювання на Google
 
 #, python-format
 msgid "Template syntax error: %s"
-msgstr ""
+msgstr "Синтаксична помилка шаблону: %s"
 
 msgid "'Active until' must be after 'Active from'."
-msgstr ""
+msgstr "«Активний до» мусить бути після «Активний з»."
 
-#, fuzzy
-#| msgid "Asset History"
 msgid "Version History"
-msgstr "Історія активу"
+msgstr "Історія версій"
 
-#, fuzzy
-#| msgid "File Preview"
 msgid "Content Preview"
-msgstr "Попередній перегляд файлу"
+msgstr "Перегляд вмісту"
 
 msgid "Sites"
-msgstr ""
+msgstr "Сайти"
 
-#, fuzzy
-#| msgid "Schedule"
 msgid "Scheduling"
-msgstr "Розклад"
+msgstr "Планування"
 
 msgid ""
 "Leave both blank to always serve this template (subject to state). Set "
 "Active From / Active Until to restrict serving to a time window."
 msgstr ""
+"Залиште обидва поля порожніми, щоб завжди віддавати цей шаблон (з "
+"урахуванням стану). Задайте «Активний з / до», щоб обмежити часовим вікном."
 
-#, fuzzy
-#| msgid "Edit"
 msgid "Edit Lock"
-msgstr "Редагувати"
+msgstr "Блокування редагування"
 
 msgid ""
 "A template is automatically locked when someone opens the edit page. Locks "
 "expire after 30 minutes or when the editor saves/cancels."
 msgstr ""
+"Шаблон автоматично блокується, коли хтось відкриває сторінку редагування. "
+"Блокування спливає через 30 хвилин або коли редактор зберігає/скасовує."
 
-#, fuzzy
-#| msgid "Task Status"
 msgid "Lock Status"
-msgstr "Статус завдання"
+msgstr "Статус блокування"
 
 msgid "Save the template first to enable live preview."
-msgstr ""
+msgstr "Спершу збережіть шаблон, щоб увімкнути живий перегляд."
 
 msgid "Opens in a new tab. Uses a dummy/empty context."
 msgstr ""
+"Відкривається в новій вкладці. Використовує тестовий/порожній контекст."
 
-#, fuzzy
-#| msgid "File Preview"
 msgid "Live Preview"
-msgstr "Попередній перегляд файлу"
+msgstr "Живий перегляд"
 
 #, python-format
 msgid ""
 "⚠️ Warning: %(user)s has been editing this template since %(time)s. Saving "
 "will overwrite their changes."
 msgstr ""
+"⚠️ Увага: %(user)s редагує цей шаблон з %(time)s. Збереження перезапише його"
+" зміни."
 
 #, python-format
 msgid "Template '%(name)s' restored to version %(v)d."
-msgstr ""
+msgstr "Шаблон '%(name)s' відновлено до версії %(v)d."
 
-#, fuzzy
-#| msgid "Question Template"
 msgid "Restore Template Version"
-msgstr "Шаблон питання"
+msgstr "Відновити версію шаблону"
 
-#, fuzzy
-#| msgid "No records available."
 msgid "No versions available."
-msgstr "Немає доступних записів."
+msgstr "Версій немає."
 
 #, python-format
 msgid "Template Diff — %(name)s"
-msgstr ""
+msgstr "Різниця шаблонів — %(name)s"
 
 #, python-format
 msgid "Live Preview — %(name)s"
-msgstr ""
+msgstr "Живий перегляд — %(name)s"
 
 msgid "Only a superuser or the locking user can force-unlock."
-msgstr ""
+msgstr "Примусово розблокувати може лише суперюзер або той, хто заблокував."
 
 #, python-format
 msgid "Template '%(name)s' unlocked."
-msgstr ""
+msgstr "Шаблон '%(name)s' розблоковано."
 
 msgid "✅ Set selected templates to ACTIVE"
-msgstr ""
+msgstr "✅ Активувати вибрані шаблони"
 
 #, python-format
 msgid "%(n)d template set to Active."
 msgid_plural "%(n)d templates set to Active."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%(n)d шаблон активовано."
+msgstr[1] "%(n)d шаблони активовано."
+msgstr[2] "%(n)d шаблонів активовано."
 
 msgid "🗄️ Archive selected templates"
-msgstr ""
+msgstr "🗄️ Заархівувати вибрані шаблони"
 
-#, fuzzy, python-format
-#| msgid "Employee archived"
+#, python-format
 msgid "%(n)d template archived."
 msgid_plural "%(n)d templates archived."
-msgstr[0] "Працівника заархівовано"
-msgstr[1] "Працівника заархівовано"
-msgstr[2] "Працівника заархівовано"
+msgstr[0] "%(n)d шаблон заархівовано."
+msgstr[1] "%(n)d шаблони заархівовано."
+msgstr[2] "%(n)d шаблонів заархівовано."
 
 msgid "📝 Set selected templates to DRAFT"
-msgstr ""
+msgstr "📝 Перевести вибрані шаблони в ЧЕРНЕТКУ"
 
 #, python-format
 msgid "%(n)d template set to Draft."
 msgid_plural "%(n)d templates set to Draft."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%(n)d шаблон переведено в чернетку."
+msgstr[1] "%(n)d шаблони переведено в чернетку."
+msgstr[2] "%(n)d шаблонів переведено в чернетку."
 
 msgid "🗑️ Invalidate cache of selected templates"
-msgstr ""
+msgstr "🗑️ Скинути кеш вибраних шаблонів"
 
 #, python-format
 msgid "Cache of %(n)d template invalidated."
 msgid_plural "Cache of %(n)d templates invalidated."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Кеш %(n)d шаблону скинуто."
+msgstr[1] "Кеш %(n)d шаблонів скинуто."
+msgstr[2] "Кеш %(n)d шаблонів скинуто."
 
 msgid "♻️ Repopulate cache for selected templates"
-msgstr ""
+msgstr "♻️ Поповнити кеш вибраних шаблонів"
 
 #, python-format
 msgid "Cache repopulated for %(n)d template."
 msgid_plural "Cache repopulated for %(n)d templates."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "Кеш поповнено для %(n)d шаблону."
+msgstr[1] "Кеш поповнено для %(n)d шаблонів."
+msgstr[2] "Кеш поповнено для %(n)d шаблонів."
 
 msgid "🔍 Check syntax of selected templates"
-msgstr ""
+msgstr "🔍 Перевірити синтаксис вибраних шаблонів"
 
 #, python-format
 msgid "Syntax errors in %(n)d template(s): %(names)s"
-msgstr ""
+msgstr "Синтаксичні помилки в %(n)d шаблон(ах): %(names)s"
 
-#, fuzzy, python-format
-#| msgid "No template have been established yet."
+#, python-format
 msgid "%(n)d template(s) have valid syntax."
-msgstr "Наразі не створено жодного шаблону."
+msgstr "%(n)d шаблон(ів) мають правильний синтаксис."
 
 msgid "🔓 Force-unlock selected templates"
-msgstr ""
+msgstr "🔓 Примусово розблокувати вибрані шаблони"
 
 msgid "Only superusers can force-unlock templates."
-msgstr ""
+msgstr "Лише суперюзери можуть примусово розблокувати шаблони."
 
 #, python-format
 msgid "%(n)d template unlocked."
 msgid_plural "%(n)d templates unlocked."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%(n)d шаблон розблоковано."
+msgstr[1] "%(n)d шаблони розблоковано."
+msgstr[2] "%(n)d шаблонів розблоковано."
 
 msgid "📥 Export selected templates as JSON fixture"
-msgstr ""
+msgstr "📥 Експортувати вибрані шаблони як JSON-фікстуру"
 
 msgid "Size"
-msgstr ""
+msgstr "Розмір"
 
-#, fuzzy
-#| msgid "Mail Templates"
 msgid "Database Templates"
-msgstr "Шаблони листів"
+msgstr "Шаблони в базі"
 
-#, fuzzy
-#| msgid "Username"
 msgid "name"
-msgstr "Ім'я користувача"
+msgstr "назва"
 
 msgid "Example: 'flatpages/default.html'"
-msgstr ""
+msgstr "Приклад: 'flatpages/default.html'"
 
-#, fuzzy
-#| msgid "Unknown content"
 msgid "content"
-msgstr "Невідомо"
+msgstr "вміст"
 
-#, fuzzy
-#| msgid "State"
 msgid "state"
 msgstr "Область"
 
 msgid "Only ACTIVE templates are served by the DB template loader."
-msgstr ""
+msgstr "Завантажувач шаблонів із БД віддає лише АКТИВНІ шаблони."
 
 msgid "sites"
-msgstr ""
+msgstr "сайти"
 
-#, fuzzy
-#| msgid "Languages"
 msgid "language"
-msgstr "Мови"
+msgstr "мова"
 
 msgid ""
 "Optional language code (e.g. 'ar', 'fr'). Leave blank for all languages."
-msgstr ""
+msgstr "Необов'язковий код мови (напр. 'ar', 'fr'). Порожнє — для всіх мов."
 
 msgid "tags"
-msgstr ""
+msgstr "теги"
 
 msgid "Comma-separated tags. E.g. 'email,onboarding,pdf'"
-msgstr ""
+msgstr "Теги через кому. Напр. 'email,onboarding,pdf'"
 
-#, fuzzy
-#| msgid "End date from"
 msgid "active from"
-msgstr "Дата закінчення з"
+msgstr "активний з"
 
 msgid ""
 "Serve this template only after this datetime. Leave blank = no restriction."
 msgstr ""
+"Віддавати цей шаблон лише після цієї дати й часу. Порожнє = без обмежень."
 
 msgid "active until"
-msgstr ""
+msgstr "активний до"
 
 msgid ""
 "Stop serving this template after this datetime. Leave blank = no "
 "restriction."
 msgstr ""
+"Припинити віддавати цей шаблон після цієї дати й часу. Порожнє = без "
+"обмежень."
 
-#, fuzzy
-#| msgid "Allocated By"
 msgid "Locked By"
-msgstr "Видав(ла)"
+msgstr "Заблокував(ла)"
 
-#, fuzzy
-#| msgid "blocked"
 msgid "Locked At"
-msgstr "заблоковано"
+msgstr "Заблоковано о"
 
-#, fuzzy
-#| msgid "Face Count"
 msgid "Access Count"
-msgstr "Кількість зразків обличчя"
+msgstr "Кількість доступів"
 
-#, fuzzy
-#| msgid "Last message:"
 msgid "Last Accessed At"
-msgstr "Останнє повідомлення:"
+msgstr "Останній доступ"
 
 msgid "Updated At"
 msgstr "Оновлено"
 
-#, fuzzy
-#| msgid "Updated"
 msgid "Updated By"
-msgstr "Оновлено"
+msgstr "Оновив(ла)"
 
 msgid "Templates"
 msgstr "Шаблони"
 
 #, python-format
 msgid "Template syntax error: %(error)s"
-msgstr ""
+msgstr "Синтаксична помилка шаблону: %(error)s"
 
-#, fuzzy
-#| msgid "Template"
 msgid "template"
 msgstr "Шаблон"
 
-#, fuzzy
-#| msgid "Permissions"
 msgid "version"
-msgstr "Дозволи"
+msgstr "версія"
 
-#, fuzzy
-#| msgid "Templates"
 msgid "Template Version"
-msgstr "Шаблони"
+msgstr "Версія шаблону"
 
-#, fuzzy
-#| msgid "Templates"
 msgid "Template Versions"
-msgstr "Шаблони"
+msgstr "Версії шаблону"
 
-#, fuzzy
-#| msgid "Template"
 msgid "Template Diff"
-msgstr "Шаблон"
+msgstr "Різниця шаблонів"
 
 msgid "Diff"
-msgstr ""
+msgstr "Різниця"
 
-#, fuzzy, python-format
-#| msgid "Add %(name)s"
+#, python-format
 msgid "Diff — %(name)s"
-msgstr "Додати %(name)s"
+msgstr "Різниця — %(name)s"
 
-#, fuzzy
-#| msgid "Group Permissions"
 msgid "From Version"
-msgstr "Дозволи групи"
+msgstr "З версії"
 
 msgid "To Version"
-msgstr ""
+msgstr "До версії"
 
-#, fuzzy
-#| msgid "Companies"
 msgid "Compare"
-msgstr "Компанії"
+msgstr "Порівняти"
 
-#, fuzzy
-#| msgid "Mail Templates"
 msgid "Back to Template"
-msgstr "Шаблони листів"
+msgstr "Назад до шаблону"
 
 #, python-format
 msgid "Preview — %(name)s"
-msgstr ""
+msgstr "Перегляд — %(name)s"
 
-#, fuzzy
-#| msgid "Error:"
 msgid "Render Error:"
-msgstr "Помилка:"
+msgstr "Помилка рендеру:"
 
 msgid ""
 "This preview renders with a minimal dummy context (request, user, now). "
 "Variables that depend on your real views may be empty or missing."
 msgstr ""
+"Цей перегляд рендериться з мінімальним тестовим контекстом (request, user, "
+"now). Змінні, що залежать від ваших справжніх view, можуть бути порожні або "
+"відсутні."
 
-#, fuzzy
-#| msgid "Refresh Token"
 msgid "Refresh"
-msgstr "Оновити токен"
+msgstr "Оновити"
 
 msgid "Restore Version"
-msgstr ""
+msgstr "Відновити версію"
 
 #, python-format
 msgid "Restore \"%(name)s\" to Version %(v)s"
-msgstr ""
+msgstr "Відновити \"%(name)s\" до версії %(v)s"
 
-#, fuzzy
-#| msgid "Are you sure want to remove this employee from this action?"
 msgid "You are about to restore this template to version"
-msgstr "Ви впевнені, що хочете видалити цього співробітника з цього заходу?"
+msgstr "Ви збираєтесь відновити цей шаблон до версії"
 
 msgid ""
 "The current content will be replaced and a new version snapshot will be "
 "created automatically."
 msgstr ""
+"Поточний вміст буде замінено, а знімок нової версії створиться автоматично."
 
 #, python-format
 msgid ""
@@ -12067,16 +10788,15 @@ msgid ""
 "      This version was saved by <strong>%(user)s</strong> at %(ts)s.\n"
 "    "
 msgstr ""
+"\n"
+"      Цю версію зберіг <strong>%(user)s</strong> о %(ts)s.\n"
+"    "
 
-#, fuzzy
-#| msgid "Current User"
 msgid "Diff: Current vs Version"
-msgstr "Поточний користувач"
+msgstr "Різниця: поточна та версія"
 
-#, fuzzy
-#| msgid "Confirm Password"
 msgid "Confirm Restore"
-msgstr "Підтвердіть пароль"
+msgstr "Підтвердіть відновлення"
 
 msgid "Format"
 msgstr "Формат"
@@ -12099,53 +10819,45 @@ msgstr "Розмір файлу перевищує ліміт"
 msgid "Please upload {} file only."
 msgstr "Будь ласка, завантажуйте лише файли {}."
 
-#, fuzzy
-#| msgid "LDAP Configuration"
 msgid "LDAP Integration"
-msgstr "Налаштування LDAP"
+msgstr "Інтеграція LDAP"
 
 msgid ""
 "Configure LDAP settings to authenticate and sync employees from your "
 "directory server."
 msgstr ""
+"Налаштуйте LDAP для автентифікації й синхронізації співробітників із вашого "
+"каталогу."
 
 msgid "Configuration updated successfully."
 msgstr "Налаштування успішно оновлено."
 
 msgid "Comma separated URIs"
-msgstr ""
+msgstr "URI через кому"
 
 msgid "Duration in minutes"
-msgstr ""
+msgstr "Тривалість у хвилинах"
 
 msgid "Meeting with this Event already exists"
 msgstr "Зустріч із цією подією вже існує"
 
-#, fuzzy
-#| msgid "Attendances"
 msgid "Attendees"
-msgstr "Відвідування"
+msgstr "Учасники"
 
-#, fuzzy
-#| msgid "Google Meeting not found."
 msgid "Google meeting"
-msgstr "Google Meeting не знайдено."
+msgstr "Зустріч Google"
 
-#, fuzzy
-#| msgid "Google Meeting not found."
 msgid "Google Meet Integration"
-msgstr "Google Meeting не знайдено."
+msgstr "Інтеграція Google Meet"
 
-#, fuzzy
-#| msgid "Enable Google Meet"
 msgid "Enable Google meet"
 msgstr "Увімкніть Google Meet"
 
 msgid "Enable this to integrate Google meet to Horilla."
-msgstr ""
+msgstr "Увімкніть, щоб інтегрувати Google Meet у Horilla."
 
 msgid "Schedule and join Google Meet video calls directly from Horilla."
-msgstr ""
+msgstr "Плануйте та приєднуйтесь до відеозвінків Google Meet прямо з Horilla."
 
 msgid "Google Cloud Credential not found."
 msgstr "Облікові дані Google Cloud не знайдено."
@@ -12176,42 +10888,34 @@ msgstr "Помилка видалення Google Meeting: %(e)s"
 msgid "Meeting created successfully"
 msgstr "Зустріч успішно створена"
 
-#, fuzzy
-#| msgid "Meeting created successfully"
 msgid "Meeting updated successfully"
-msgstr "Зустріч успішно створена"
+msgstr "Зустріч успішно оновлено"
 
 #, python-format
 msgid "Error creating/updating Google Meeting: %(error)s"
 msgstr "Помилка створення/оновлення Google Meeting: %(error)s"
 
 msgid "Is Default"
-msgstr ""
+msgstr "За замовчуванням"
 
 msgid ""
 "Set as default theme for login page. Only one theme can be default across "
 "all companies."
 msgstr ""
+"Зробити типовою темою для сторінки входу. Типовою може бути лише одна тема "
+"для всіх компаній."
 
-#, fuzzy
-#| msgid "Color Theme"
 msgid "Color Themes"
-msgstr "Кольорова тема"
+msgstr "Колірні теми"
 
-#, fuzzy
-#| msgid "Color Theme"
 msgid "Theme"
-msgstr "Кольорова тема"
+msgstr "Тема"
 
-#, fuzzy
-#| msgid "Company Name"
 msgid "Company Theme"
-msgstr "Назва компанії"
+msgstr "Тема компанії"
 
-#, fuzzy
-#| msgid "Company Leaves"
 msgid "Company Themes"
-msgstr "Відпустки компанії"
+msgstr "Теми компанії"
 
 msgid "Reason for Cancellation"
 msgstr "Причина скасування"
@@ -12222,15 +10926,11 @@ msgstr "Причина відхилення"
 msgid "View attachment"
 msgstr "Переглянути вкладення"
 
-#, fuzzy
-#| msgid "Activities"
 msgid "Activities:"
 msgstr "Активність"
 
-#, fuzzy
-#| msgid "View assets"
 msgid "View Clashes"
-msgstr "Переглянути активи"
+msgstr "Переглянути накладки"
 
 msgid "Tax"
 msgstr "Податок"
@@ -12277,44 +10977,34 @@ msgstr "Одноразове утримання"
 msgid "Deduction Eligibility"
 msgstr "Право на утримання"
 
-#, fuzzy
-#| msgid "Clear Filter"
 msgid "Clear Filters"
-msgstr "Очистити фільтр"
+msgstr "Очистити фільтри"
 
 msgid "This will clear all filters you have applied."
-msgstr ""
+msgstr "Це очистить усі застосовані вами фільтри."
 
-#, fuzzy
-#| msgid "The employees selected here will receive the email as Cc."
 msgid ""
 "Only the employees selected in any of the fields will have access to the "
-msgstr "Обрані тут співробітники отримають лист у копії (Cc)."
+msgstr "Доступ отримають лише співробітники, вибрані в будь-якому з полів "
 
 msgid ""
 "If none are selected, the feature will be available to all normal users and "
 "employees."
 msgstr ""
+"Якщо не вибрано жодного, функція буде доступна всім звичайним користувачам і"
+" співробітникам."
 
-#, fuzzy
-#| msgid " Views"
 msgid "Views"
 msgstr " Перегляди"
 
-#, fuzzy
-#| msgid "Comments"
 msgid "Comments disabled"
-msgstr "Коментарі"
+msgstr "Коментарі вимкнено"
 
-#, fuzzy
-#| msgid "Comments"
 msgid "Comments of - "
-msgstr "Коментарі"
+msgstr "Коментарі до - "
 
-#, fuzzy
-#| msgid "Are you sure you want to delete this company?"
 msgid "Are you sure you want to delete this comment?"
-msgstr "Ви впевнені, що хочете видалити цю компанію?"
+msgstr "Ви впевнені, що хочете видалити цей коментар?"
 
 msgid ""
 "Number of days after which an announcement automatically expires when no "
@@ -12323,153 +11013,115 @@ msgstr ""
 "Кількість днів, після яких оголошення автоматично закінчується, якщо дату "
 "завершення не вказано."
 
-#, fuzzy
-#| msgid "Tracking Id"
 msgid "Tracking ID"
 msgstr "Ідентифікатор відстеження"
 
-#, fuzzy
-#| msgid "Reports"
 msgid "Report"
-msgstr "Звіти"
+msgstr "Звіт"
 
-#, fuzzy
-#| msgid "Asset Return Form"
 msgid "Asset Return"
-msgstr "Форма повернення активу"
+msgstr "Повернення активу"
 
 msgid "Attendance Analytics"
 msgstr "Аналітика відвідуваності"
 
-#, fuzzy
-#| msgid "On Leave"
 msgid "Minius Leave"
-msgstr "У відпустці"
+msgstr "Мінус відпустка"
 
-#, fuzzy
-#| msgid "Maximum Carryforward"
 msgid "Deduct From Carryforward"
-msgstr "Максимальне перенесення"
+msgstr "Утримати з перенесених"
 
-#, fuzzy
-#| msgid "Export Records"
 msgid "Export Work Records"
-msgstr "Експортувати записи"
+msgstr "Експортувати записи роботи"
 
-#, fuzzy
-#| msgid "File Uploaded"
 msgid "File name:"
-msgstr "Файл завантажено"
+msgstr "Назва файлу:"
 
-#, fuzzy
-#| msgid "Format"
 msgid "Format:"
 msgstr "Формат"
 
-#, fuzzy
-#| msgid "Excel columns"
 msgid "Excel (.xlsx)"
-msgstr "Стовпці Excel"
+msgstr "Excel (.xlsx)"
 
 msgid "CSV (.csv)"
-msgstr ""
+msgstr "CSV (.csv)"
 
-#, fuzzy
-#| msgid "On leave, But attendance exist"
 msgid "On Leave, But Attendance Exist"
 msgstr "У відпустці, але відвідуваність існує"
 
-#, fuzzy
-#| msgid "Allow admins to block or unblock employee login"
 msgid "Allow administrators to block or unblock employee login accounts."
 msgstr ""
-"Дозволити адміністраторам блокувати або розблокувати вхід співробітників"
+"Дозволити адміністраторам блокувати або розблоковувати входи співробітників."
 
-#, fuzzy
-#| msgid "Prevent employees from editing their own profile"
 msgid "Prevent employees from editing their own profile details."
-msgstr "Заборонити працівникам редагувати власний профіль"
+msgstr "Заборонити співробітникам редагувати власні дані профілю."
 
-#, fuzzy
-#| msgid ""
-#| "Enable tracking of changes to employee work information fields"
 msgid ""
 "Save a history record whenever an employee's work information is updated."
 msgstr ""
-"Увімкнути відстеження змін у полях інформації про роботу співробітника"
+"Зберігати запис історії щоразу, коли оновлюється робоча інформація "
+"співробітника."
 
 msgid ""
 "Selected fields will be recorded in employee history whenever they are "
 "updated."
 msgstr ""
+"Вибрані поля фіксуватимуться в історії співробітника щоразу при оновленні."
 
 msgid ""
 "A role is a named set of employees who share the same access. Create a role,"
 " add members, then turn permissions on or off."
 msgstr ""
+"Роль — це названий набір співробітників зі однаковим доступом. Створіть "
+"роль, додайте учасників, потім увімкніть або вимкніть дозволи."
 
-#, fuzzy
-#| msgid "Created Date"
 msgid "Create a role"
-msgstr "Дата створення"
+msgstr "Створити роль"
 
-#, fuzzy
-#| msgid "Add Employee"
 msgid "Add employees (Members)"
-msgstr "Додати співробітника"
+msgstr "Додати співробітників (учасників)"
 
-#, fuzzy
-#| msgid "Roles and Permissions"
 msgid "Set what they can do (Permissions)"
-msgstr "Ролі та дозволи"
+msgstr "Визначте, що вони можуть робити (дозволи)"
 
-#, fuzzy
-#| msgid "Search for Jobs..."
 msgid "Search roles..."
-msgstr "Пошук роботи..."
+msgstr "Пошук ролей..."
 
-#, fuzzy
-#| msgid "Create "
 msgid "Create role"
-msgstr "Створити "
+msgstr "Створити роль"
 
-#, fuzzy
-#| msgid "onboarding"
 msgid "Loading…"
-msgstr "адаптація"
+msgstr "Завантаження…"
 
-#, fuzzy
-#| msgid "Task members"
 msgid "Role members"
-msgstr "Учасники завдання"
+msgstr "Учасники ролі"
 
 msgid "Server error."
-msgstr ""
+msgstr "Помилка сервера."
 
-#, fuzzy
-#| msgid "Model name"
 msgid "Role name"
-msgstr "Назва моделі"
+msgstr "Назва ролі"
 
 msgid "Members"
 msgstr "Учасники"
 
 msgid "People in this role get all of its permissions."
-msgstr ""
+msgstr "Люди з цією роллю отримують усі її дозволи."
 
 msgid "No one is in this role yet."
-msgstr ""
+msgstr "У цій ролі ще нікого немає."
 
 msgid ""
 "Pick a module on the left, then turn Create / View / Edit / Delete on. Use "
 "View only or Full access for faster setup. Changes save automatically."
 msgstr ""
+"Виберіть модуль ліворуч, потім увімкніть Створення / Перегляд / Редагування "
+"/ Видалення. Для швидшого налаштування скористайтеся «Лише перегляд» або "
+"«Повний доступ». Зміни зберігаються автоматично."
 
 msgid "Click to rename"
-msgstr ""
+msgstr "Натисніть, щоб перейменувати"
 
-#, fuzzy
-#| msgid "Permissions"
 msgid "permissions"
 msgstr "Дозволи"
 
@@ -12477,26 +11129,24 @@ msgid ""
 "Delete this role? Employees will keep their accounts, but will no longer get"
 " permissions from this role."
 msgstr ""
+"Видалити цю роль? Співробітники збережуть акаунти, але більше не "
+"отримуватимуть дозволи від цієї ролі."
 
-#, fuzzy
-#| msgid "Delete Comment"
 msgid "Delete role"
-msgstr "Видалити коментар"
+msgstr "Видалити роль"
 
-#, fuzzy
-#| msgid "No answers yet."
 msgid "No roles yet"
-msgstr "Поки що немає відповідей."
+msgstr "Ролей ще немає"
 
 msgid ""
 "Create a group, add employees, then choose what they can access. You can "
 "change this anytime."
 msgstr ""
+"Створіть групу, додайте співробітників, потім виберіть, до чого вони мають "
+"доступ. Це можна змінити будь-коли."
 
-#, fuzzy
-#| msgid " Create template group"
 msgid "Create your first group"
-msgstr " Створити групу шаблонів"
+msgstr "Створіть свою першу групу"
 
 msgid "Previous Page"
 msgstr "Попередня"
@@ -12506,76 +11156,65 @@ msgstr "Наступна сторінка"
 
 #, python-format
 msgid "Remove %(cname)s from %(name)s's assignment?"
-msgstr ""
+msgstr "Вилучити %(cname)s з призначення %(name)s?"
 
-#, fuzzy
-#| msgid "Select the company."
 msgid "Remove this company"
-msgstr "Виберіть компанію."
+msgstr "Видалити цю компанію"
 
 msgid "No company assignments"
-msgstr ""
+msgstr "Немає призначень до компаній"
 
 #, python-format
 msgid "Remove %(name)s from this group?"
-msgstr ""
+msgstr "Вилучити %(name)s з цієї групи?"
 
-#, fuzzy
-#| msgid "Remove from sorting"
 msgid "Remove from group"
-msgstr "Вилучити із сортування"
+msgstr "Вилучити з групи"
 
 #, python-format
 msgid "Edit members of \"%(name)s\""
-msgstr ""
+msgstr "Редагувати учасників \"%(name)s\""
 
-#, fuzzy, python-format
-#| msgid "Add %(name)s"
+#, python-format
 msgid "Add members to \"%(name)s\""
-msgstr "Додати %(name)s"
+msgstr "Додати учасників до \"%(name)s\""
 
 msgid ""
 "Update employees or companies for this role. Saving applies the selected "
 "employees to the selected companies."
 msgstr ""
+"Оновіть співробітників або компанії для цієї ролі. Збереження застосує "
+"вибраних співробітників до вибраних компаній."
 
 msgid ""
 "Search and pick employees below. Saving adds the selected employees to this "
 "role for the selected companies."
 msgstr ""
+"Знайдіть і виберіть співробітників нижче. Збереження додає вибраних до цієї "
+"ролі для вибраних компаній."
 
 #, python-format
 msgid "%(counter)s member currently in this role."
 msgid_plural "%(counter)s members currently in this role."
-msgstr[0] ""
-msgstr[1] ""
-msgstr[2] ""
+msgstr[0] "%(counter)s учасник зараз у цій ролі."
+msgstr[1] "%(counter)s учасники зараз у цій ролі."
+msgstr[2] "%(counter)s учасників зараз у цій ролі."
 
-#, fuzzy
-#| msgid "Employee not provided"
 msgid "Employees in this role"
-msgstr "Співробітника не вказано"
+msgstr "Співробітники з цією роллю"
 
-#, fuzzy
-#| msgid "Employee tag"
 msgid "Employees to add"
-msgstr "Тег співробітника"
+msgstr "Співробітники для додавання"
 
 msgid "Use search or filters to find people quickly."
-msgstr ""
+msgstr "Скористайтеся пошуком або фільтрами, щоб швидко знайти людей."
 
-#, fuzzy
-#| msgid "Save Changes"
 msgid "Save changes"
 msgstr "Зберегти зміни"
 
-#, fuzzy
-#| msgid "Task members"
 msgid "Add members"
-msgstr "Учасники завдання"
+msgstr "Додати учасників"
 
-#, fuzzy
-#| msgid "Forgot Password"
 msgid "Forgot Password ?"
 msgstr "Забули пароль"
 
@@ -12584,113 +11223,90 @@ msgstr "Дозволи користувача"
 
 msgid "Review or assign permissions directly to individual employees."
 msgstr ""
+"Перегляньте або призначте дозволи безпосередньо окремим співробітникам."
 
 msgid ""
 "Permissions assigned directly to an employee here apply in all companies. "
 "Use Roles to grant company-specific permissions."
 msgstr ""
+"Дозволи, призначені співробітнику тут напряму, діють у всіх компаніях. Для "
+"дозволів по компаніях використовуйте Ролі."
 
 msgid "Search module or feature…"
-msgstr ""
+msgstr "Пошук модуля або функції…"
 
-#, fuzzy
-#| msgid "User Permissions"
 msgid "Search permissions"
-msgstr "Дозволи користувача"
+msgstr "Пошук дозволів"
 
-#, fuzzy
-#| msgid "Selected"
 msgid "selected"
 msgstr "Вибрано"
 
 msgid "No features match your search."
-msgstr ""
+msgstr "Жодна функція не відповідає пошуку."
 
 msgid ""
 "Permissions from this employee's groups in the selected company (plus any "
 "direct permissions)."
 msgstr ""
+"Дозволи з груп цього співробітника у вибраній компанії (плюс будь-які прямі "
+"дозволи)."
 
 msgid "Only allow viewing"
-msgstr ""
+msgstr "Дозволити лише перегляд"
 
-#, fuzzy
-#| msgid "View policy"
 msgid "View only"
-msgstr "Переглянути політику"
+msgstr "Лише перегляд"
 
 msgid "Allow create, view, edit, delete and other actions"
-msgstr ""
+msgstr "Дозволити створення, перегляд, редагування, видалення та інші дії"
 
-#, fuzzy
-#| msgid "Full Name"
 msgid "Full access"
-msgstr "Повне ім'я"
+msgstr "Повний доступ"
 
-#, fuzzy
-#| msgid "Clear all filters"
 msgid "Clear all in this module"
-msgstr "Очистити всі фільтри"
+msgstr "Очистити все в цьому модулі"
 
 msgid "Clear"
 msgstr "Очистити"
 
-#, fuzzy
-#| msgid "Select all users"
 msgid "Select all for this module"
-msgstr "Вибрати всіх користувачів"
+msgstr "Вибрати все для цього модуля"
 
-#, fuzzy
-#| msgid "feature"
 msgid "Feature"
 msgstr "функція"
 
-#, fuzzy
-#| msgid "Can edit"
 msgid "Can export"
-msgstr "Може редагувати"
+msgstr "Може експортувати"
 
 msgid "Extra actions defined for this feature"
-msgstr ""
+msgstr "Додаткові дії, визначені для цієї функції"
 
-#, fuzzy
-#| msgid "Select all users"
 msgid "Select all for this feature"
-msgstr "Вибрати всіх користувачів"
+msgstr "Вибрати все для цієї функції"
 
-#, fuzzy
-#| msgid "Enter New Username"
 msgid "New Username"
-msgstr "Введіть нове ім'я користувача"
+msgstr "Нове ім'я користувача"
 
 msgid "Number of records shown per page across all list views."
 msgstr "Кількість записів на сторінці в усіх списках."
 
-#, fuzzy
-#| msgid "Search in : Company"
 msgid "Search company"
-msgstr "Пошук за: Компанія"
+msgstr "Пошук компанії"
 
 msgid "user"
 msgstr "користувач"
 
-#, fuzzy
-#| msgid "How dates are displayed across the system"
 msgid "Select how dates are displayed across the system."
-msgstr "Як дати відображаються в системі"
+msgstr "Виберіть, як дати відображаються в системі."
 
-#, fuzzy
-#| msgid "How dates are displayed across the system"
 msgid "Select how times are displayed across the system."
-msgstr "Як дати відображаються в системі"
+msgstr "Виберіть, як час відображається в системі."
 
 msgid "Application Form"
 msgstr "Форма заявки"
 
-#, fuzzy
-#| msgid "Description"
 msgid "Job Description"
-msgstr "Опис"
+msgstr "Опис посади"
 
 msgid "Enter your name"
 msgstr "Введіть своє ім'я"
@@ -12737,38 +11353,26 @@ msgstr "напр. Керала"
 msgid "e.g. 611 293"
 msgstr "напр. 611 293"
 
-#, fuzzy
-#| msgid "Application Form"
 msgid "Submit Application"
-msgstr "Форма заявки"
+msgstr "Надіслати заявку"
 
-#, fuzzy
-#| msgid "Basic Pay"
 msgid "Basic Identity"
-msgstr "Базова оплата"
+msgstr "Основні дані"
 
-#, fuzzy
-#| msgid "Company Address"
 msgid "Contact & Address"
-msgstr "Адреса компанії"
+msgstr "Контакти та адреса"
 
 msgid "Personal Details"
 msgstr "Особисті дані"
 
-#, fuzzy
-#| msgid "Offer Status"
 msgid "Referral & Status"
-msgstr "Статус пропозиції"
+msgstr "Реферал і статус"
 
-#, fuzzy
-#| msgid "Change"
 msgid "Changes"
-msgstr "Змінити"
+msgstr "Зміни"
 
-#, fuzzy
-#| msgid "Are you sure you want to delete this stage?"
 msgid "Are you sure you want to delete this note?"
-msgstr "Ви впевнені, що хочете видалити цей етап?"
+msgstr "Ви впевнені, що хочете видалити цю нотатку?"
 
 msgid "stage"
 msgstr "етап"
@@ -12791,46 +11395,30 @@ msgstr "2 зірки"
 msgid "1 Star"
 msgstr "Зірка"
 
-#, fuzzy
-#| msgid "No penalties found."
 msgid "No rating found."
-msgstr "Штрафів не знайдено."
+msgstr "Оцінок не знайдено."
 
-#, fuzzy
-#| msgid "Do you want to delete this Allowance?"
 msgid "Do you want to delete this allowance ?"
 msgstr "Ви бажаєте видалити цю надбавку?"
 
 msgid "Do you want to delete this deduction?"
 msgstr "Ви бажаєте видалити це утримання?"
 
-#, fuzzy
-#| msgid "Do you want to delete this asset?"
 msgid "Do you want to delete this asset ?"
 msgstr "Ви бажаєте видалити цей актив?"
 
-#, fuzzy
-#| msgid "Are you sure you want to delete this assigned leave?"
 msgid "Are you sure you want to delete this assigned leave request?"
 msgstr "Ви впевнені, що хочете видалити цю призначену відпустку?"
 
-#, fuzzy
-#| msgid "Do you want to Approve this leave request?"
 msgid "Do you want to approve this attendance request?"
-msgstr "Ви хочете затвердити цей запит на відпустку?"
+msgstr "Ви бажаєте затвердити цю заявку на відвідування?"
 
-#, fuzzy
-#| msgid "Do you want to reject this asset request?"
 msgid "Do you want to reject this attendance request?"
-msgstr "Ви бажаєте відхилити цей запит на актив?"
+msgstr "Ви бажаєте відхилити цю заявку на відвідування?"
 
-#, fuzzy
-#| msgid "Are you sure want to delete this attendance?"
 msgid "Are you sure you want to delete this attendance?"
 msgstr "Ви впевнені, що хочете видалити це відвідування?"
 
-#, fuzzy
-#| msgid "Date of Birth"
 msgid "Date of birth"
 msgstr "Дата народження"
 
@@ -12840,10 +11428,8 @@ msgstr "Інформація про найм"
 msgid "Recruitment"
 msgstr "Підбір персоналу"
 
-#, fuzzy
-#| msgid "Position"
 msgid "Applied Position"
-msgstr "Посада"
+msgstr "Посада, на яку подався"
 
 msgid "Current Stage"
 msgstr "Поточний етап"
@@ -12863,23 +11449,17 @@ msgstr "додати"
 msgid "Interviewers"
 msgstr "Інтерв'юери"
 
-#, fuzzy
-#| msgid "No interviews are scheduled for this candidate"
 msgid "No interviews are scheduled for this candidate."
 msgstr "Для цього кандидата не заплановано жодних співбесід"
 
-#, fuzzy
-#| msgid "Answers"
 msgid "Survey Answers"
-msgstr "Відповіді"
+msgstr "Відповіді опитування"
 
 msgid "Stars"
 msgstr "Зірки"
 
-#, fuzzy
-#| msgid "No notes have been added for this candidate."
 msgid "No Survey Added for this candidate."
-msgstr "Для цього кандидата не додано жодної нотатки."
+msgstr "Для цього кандидата опитувань не додано."
 
 msgid "Calculate Leave Amount"
 msgstr "Розрахувати суму за відпустку"
@@ -12890,43 +11470,29 @@ msgstr "Сума утримання за один день відпустки"
 msgid "Tasks"
 msgstr "Завдання"
 
-#, fuzzy
-#| msgid "Update Image"
 msgid "Update Stage Order"
-msgstr "Оновити зображення"
+msgstr "Оновити порядок етапів"
 
-#, fuzzy
-#| msgid "Validate"
 msgid "Validate Hours"
-msgstr "Перевірити"
+msgstr "Перевірити години"
 
-#, fuzzy
-#| msgid "Validate"
 msgid "Validate OT Hours"
-msgstr "Перевірити"
+msgstr "Перевірити понаднормові"
 
-#, fuzzy
-#| msgid " Are you sure you want to delete this interview?"
 msgid "Are you sure you want to delete this interview?"
 msgstr " Ви впевнені, що хочете видалити цю співбесіду?"
 
 msgid "Do you want to delete this Key result?"
 msgstr "Ви бажаєте видалити цей ключовий результат?"
 
-#, fuzzy
-#| msgid "No leave requests for this month."
 msgid "This leave request is for the month of"
-msgstr "Цього місяця немає заявок на відпустку."
+msgstr "Ця заявка на відпустку за місяць"
 
-#, fuzzy
-#| msgid "Approved Leaves In This Month"
 msgid "Approval depends on the"
-msgstr "Затверджені відпустки цього місяця"
+msgstr "Погодження залежить від"
 
-#, fuzzy
-#| msgid "You have No leave requests for this month."
 msgid "having available leave days for this month."
-msgstr "У вас немає запитів на відпустку за цей місяць."
+msgstr "які мають доступні дні відпустки цього місяця."
 
 msgid "Do you really want to approve this request?"
 msgstr "Ви дійсно бажаєте схвалити цей запит?"
@@ -12934,10 +11500,8 @@ msgstr "Ви дійсно бажаєте схвалити цей запит?"
 msgid "Multiple Approvals"
 msgstr "Множинні затвердження"
 
-#, fuzzy
-#| msgid "Are you sure you want to delete this employee type?"
 msgid "Are you sure you want to delete this leave type?"
-msgstr "Ви впевнені, що хочете видалити цей тип працівника?"
+msgstr "Ви впевнені, що хочете видалити цей тип відпустки?"
 
 msgid "Are you sure to delete this meeting?"
 msgstr "Ви впевнені, що хочете видалити цю зустріч?"
@@ -12945,8 +11509,6 @@ msgstr "Ви впевнені, що хочете видалити цю зуст�
 msgid "Are you sure you want to delete this leave request?"
 msgstr "Ви впевнені, що бажаєте видалити цю заявку на відпустку?"
 
-#, fuzzy
-#| msgid "Do you want to un-archive this employee objective?"
 msgid "Do you want to unarchive this employee objective?"
 msgstr "Ви бажаєте розархівувати цю ціль співробітника?"
 
@@ -12966,7 +11528,7 @@ msgid "with"
 msgstr "з"
 
 msgid "Sl No."
-msgstr ""
+msgstr "№"
 
 msgid "Completed"
 msgstr "Завершено"
@@ -12977,15 +11539,11 @@ msgstr "Додати кандидата"
 msgid "Do you want to delete this project?"
 msgstr "Бажаєте видалити цей проєкт?"
 
-#, fuzzy
-#| msgid "Not Available"
 msgid "No Description Available"
-msgstr "Недоступний"
+msgstr "Опис відсутній"
 
-#, fuzzy
-#| msgid "Projects"
 msgid "'s Projects"
-msgstr "Проєкти"
+msgstr " — проєкти"
 
 msgid "View Project"
 msgstr "Переглянути проєкт"
@@ -12993,23 +11551,17 @@ msgstr "Переглянути проєкт"
 msgid "No projects assigned to this employee."
 msgstr "Цьому співробітнику не призначено жодного проєкту."
 
-#, fuzzy
-#| msgid "Do you want to archive this project?"
 msgid "Do you want to archive this recruitment?"
-msgstr "Бажаєте заархівувати цей проєкт?"
+msgstr "Ви бажаєте заархівувати цю вакансію?"
 
-#, fuzzy
-#| msgid "Do you want to un-archive this ticket?"
 msgid "Do you want to un-archive this recruitment?"
-msgstr "Бажаєте розархівувати цю заявку?"
+msgstr "Ви бажаєте розархівувати цю вакансію?"
 
 msgid "Are you sure you want to delete this recruitment?"
 msgstr "Ви впевнені, що хочете видалити цей набір?"
 
-#, fuzzy
-#| msgid "Are you sure you want to delete this action type?"
 msgid "Are you sure you want to delete this survey question template?"
-msgstr "Ви впевнені, що хочете видалити цей тип дії?"
+msgstr "Ви впевнені, що хочете видалити цей шаблон питань опитування?"
 
 msgid "Add more options.."
 msgstr "Додати ще варіанти.."
@@ -13045,8 +11597,6 @@ msgstr "Бажаєте видалити цей табель обліку час�
 msgid "View Timesheet Chart"
 msgstr "Переглянути діаграму табеля обліку часу"
 
-#, fuzzy
-#| msgid "Reallocate Shift."
 msgid "Reallocate Shift"
 msgstr "Перерозподілити зміну."
 
@@ -13072,16 +11622,18 @@ msgstr "Коефіцієнт конверсії"
 
 msgid "Conversion Rate = ( Total Hired Candidates / Total Candidates ) * 100"
 msgstr ""
+"Коефіцієнт конверсії = ( Усього найнятих кандидатів / Усього кандидатів ) * "
+"100"
 
-#, fuzzy
-#| msgid "Offer Acceptance Rate (OAR)"
 msgid "Offer Acceptance Rate"
-msgstr "Рівень прийняття пропозицій (OAR)"
+msgstr "Рівень прийняття пропозицій"
 
 msgid ""
 "Offer Acceptance Rate = ( Onboarding candidates / Total Hired Candidates ) *"
 " 100"
 msgstr ""
+"Рівень прийняття пропозицій = ( Кандидати на адаптації / Усього найнятих ) *"
+" 100"
 
 msgid "Skill Zone Status"
 msgstr "Статус зони навичок"
@@ -13105,7 +11657,7 @@ msgid "My Onboarding Tasks"
 msgstr "Мої завдання з адаптації"
 
 msgid "arrow-back-outline"
-msgstr ""
+msgstr "arrow-back-outline"
 
 msgid "Total employee objectives"
 msgstr "Загальна кількість цілей працівників"
@@ -13158,112 +11710,81 @@ msgstr "Статус завдання"
 msgid "Dashboard Chart Select"
 msgstr "Вибір графіка панелі приладів"
 
-#, fuzzy
-#| msgid "Select All Shifts"
 msgid "Select All Charts"
-msgstr "Вибрати всі зміни"
+msgstr "Вибрати всі діаграми"
 
-#, fuzzy
-#| msgid "Unselect All Shifts"
 msgid "Unselect All Charts"
-msgstr "Скасувати вибір усіх змін"
+msgstr "Скасувати вибір усіх діаграм"
 
-#, fuzzy
-#| msgid "Gender Chart"
 msgid "Reorder Charts"
-msgstr "Діаграма за статтю"
+msgstr "Змінити порядок діаграм"
 
 msgid "Charts"
 msgstr "Графіки"
 
-#, fuzzy
-#| msgid "New Employee"
 msgid "Add New Employee"
-msgstr "Новий співробітник"
+msgstr "Додати співробітника"
 
 msgid "Enter the details to create a new employee profile."
-msgstr ""
+msgstr "Введіть дані, щоб створити новий профіль співробітника."
 
-#, fuzzy
-#| msgid "Employee Reports"
 msgid "Employee photo"
-msgstr "Звіти по співробітниках"
+msgstr "Фото співробітника"
 
 msgid "Upload JPG, PNG or SVG"
-msgstr ""
+msgstr "Завантажте JPG, PNG або SVG"
 
 msgid "max 5MB"
-msgstr ""
+msgstr "макс. 5 МБ"
 
-#, fuzzy
-#| msgid "Sample photo"
 msgid "Remove photo"
-msgstr "Зразок фото"
+msgstr "Видалити фото"
 
-#, fuzzy
-#| msgid "Save and continue editing"
 msgid "Save & Continue"
-msgstr "Зберегти й продовжити редагування"
+msgstr "Зберегти й продовжити"
 
-#, fuzzy
-#| msgid "Asset Information"
 msgid "Account Information"
-msgstr "Інформація про актив"
+msgstr "Інформація про акаунт"
 
-#, fuzzy
-#| msgid "{} employees information updated successfully"
 msgid "Update employee information across all sections."
-msgstr "Інформацію {} працівників успішно оновлено"
+msgstr "Оновіть інформацію про співробітника в усіх розділах."
 
-#, fuzzy
-#| msgid "Change Password"
 msgid "Change Photo"
-msgstr "Змінити пароль"
+msgstr "Змінити фото"
 
 msgid "Position"
 msgstr "Посада"
 
-#, fuzzy
-#| msgid "Employee Details"
 msgid "Employment Details"
-msgstr "Дані співробітника"
+msgstr "Дані про працевлаштування"
 
-#, fuzzy
-#| msgid "Work Location"
 msgid "Reporting & Location"
-msgstr "Місце роботи"
+msgstr "Підпорядкування та локація"
 
-#, fuzzy
-#| msgid "Update compensation"
 msgid "Contact & Compensation"
-msgstr "Оновити компенсацію"
+msgstr "Контакти та компенсація"
 
-#, fuzzy
-#| msgid "Create tags to categorise audit log records"
 msgid "Create tags used to group and filter employees."
-msgstr "Створіть теги для класифікації записів журналу аудиту"
+msgstr "Створіть теги для групування й фільтрації співробітників."
 
 msgid "Manage employee categories such as permanent or contract."
-msgstr ""
+msgstr "Керуйте категоріями співробітників, як-от постійні або за контрактом."
 
-#, fuzzy
-#| msgid "There are no rotating shift assigned to this employee."
 msgid "Set up rotating shift patterns for employees."
-msgstr "Цьому працівнику не призначено жодної позмінної ротації."
+msgstr "Налаштуйте схеми змінних змін для співробітників."
 
-#, fuzzy
-#| msgid "There are no rotating work type assigned to this employee."
 msgid "Set up rotating work type patterns for employees."
-msgstr "Цьому працівнику не призначено жодного ротаційного типу роботи."
+msgstr "Налаштуйте схеми змінних типів роботи для співробітників."
 
 msgid "Configure day-wise schedules linked to each shift."
-msgstr ""
+msgstr "Налаштуйте розклади по днях, привʼязані до кожної зміни."
 
 msgid "Create and manage shift definitions used across the organization."
 msgstr ""
+"Створюйте й керуйте визначеннями змін, що використовуються в організації."
 
 msgid "Define work modes such as office, remote, or hybrid."
-msgstr ""
+msgstr "Визначте режими роботи: офіс, віддалено або гібрид."
 
 msgid "Feedback Answer"
 msgstr "Відповідь на відгук"
@@ -13301,10 +11822,8 @@ msgstr "Середньо"
 msgid "Bad"
 msgstr "Погано"
 
-#, fuzzy
-#| msgid "Feedback Answers"
 msgid "Feedback Responses"
-msgstr "Відповіді на відгук"
+msgstr "Відповіді на відгуки"
 
 msgid "Key Results"
 msgstr "Ключові результати"
@@ -13318,28 +11837,18 @@ msgstr "Ви бажаєте видалити цей відгук?"
 msgid "Request feedback"
 msgstr "Запросити відгук"
 
-#, fuzzy
-#| msgid "requested"
 msgid "request"
-msgstr "запитано"
+msgstr "заявка"
 
-#, fuzzy
-#| msgid "Answered employees: "
 msgid "Answered Employees"
 msgstr "Відповіли співробітники: "
 
-#, fuzzy
-#| msgid "Employees not answerd yet: "
 msgid "Employees not answered yet"
-msgstr "Ще не відповіли співробітники: "
+msgstr "Співробітники, які ще не відповіли"
 
-#, fuzzy
-#| msgid "Cyclic feedback period: "
 msgid "Cyclic feedback period"
 msgstr "Період циклічного відгуку: "
 
-#, fuzzy
-#| msgid "Next feedback on: "
 msgid "Next feedback on"
 msgstr "Наступний відгук: "
 
@@ -13379,18 +11888,14 @@ msgstr "Питання"
 msgid "Do you want to delete the question?"
 msgstr "Ви бажаєте видалити це питання?"
 
-#, fuzzy
-#| msgid "Add Question"
 msgid "Edit Question"
-msgstr "Додати питання"
+msgstr "Редагувати питання"
 
 msgid "Add A Question"
 msgstr "Додати питання"
 
-#, fuzzy
-#| msgid "Enter question"
 msgid "Enter question here"
-msgstr "Введіть питання"
+msgstr "Введіть питання тут"
 
 msgid "Add Question"
 msgstr "Додати питання"
@@ -13424,64 +11929,50 @@ msgid ""
 "Login - %(company_name)s\n"
 "                Dashboard"
 msgstr ""
+"Вхід - %(company_name)s\n"
+"                Дашборд"
 
 msgid "Forgot Password"
 msgstr "Забули пароль"
 
-#, fuzzy
-#| msgid "Type in your email to reset the password"
 msgid "Type in your username to reset the password."
-msgstr "Введіть свою електронну пошту для скидання пароля"
+msgstr "Введіть своє ім'я користувача, щоб скинути пароль."
 
 msgid "e.g. jane.doe@acme.com"
-msgstr ""
+msgstr "напр. olena.koval@acme.com"
 
-#, fuzzy
-#| msgid "Send password reset link"
 msgid "Send reset link"
-msgstr "Надіслати посилання для скидання пароля"
+msgstr "Надіслати посилання для скидання"
 
 msgid "Reset link will be sent to your registered email"
-msgstr ""
+msgstr "Посилання для скидання буде надіслано на вашу пошту"
 
-#, fuzzy
-#| msgid "Excel columns"
 msgid "Customize columns"
-msgstr "Стовпці Excel"
+msgstr "Налаштувати стовпці"
 
-#, fuzzy
-#| msgid "Excel columns"
 msgid "Columns"
-msgstr "Стовпці Excel"
+msgstr "Стовпці"
 
 msgid "Show, hide, or reorder"
-msgstr ""
+msgstr "Показати, сховати або змінити порядок"
 
-#, fuzzy
-#| msgid "Excel columns"
 msgid "Search columns…"
-msgstr "Стовпці Excel"
+msgstr "Пошук стовпців…"
 
-#, fuzzy
-#| msgid "Excel columns"
 msgid "Search columns"
-msgstr "Стовпці Excel"
+msgstr "Пошук стовпців"
 
-#, fuzzy
-#| msgid "Select All Columns"
 msgid "Select all columns"
 msgstr "Вибрати всі стовпці"
 
-#, fuzzy
-#| msgid "Primary"
 msgid "Primary column"
-msgstr "Основний"
+msgstr "Основний стовпець"
 
 msgid "No columns match your search"
-msgstr ""
+msgstr "Жоден стовпець не відповідає пошуку"
 
 msgid "Drag rows to reorder columns"
-msgstr ""
+msgstr "Перетягуйте рядки, щоб змінити порядок стовпців"
 
 msgid "Delete Confirmation"
 msgstr "Підтвердження видалення"
@@ -13498,13 +11989,9 @@ msgstr "Захищені записи"
 msgid "Other Related Records"
 msgstr "Інші пов'язані записи"
 
-#, fuzzy
-#| msgid "I Have took manual action for the protected records"
 msgid "I have took manual action for the protected records"
 msgstr "Я вжив(ла) заходів вручну щодо захищених записів"
 
-#, fuzzy
-#| msgid "I acknowledge, I wont be able to revert this "
 msgid "I acknowledge, i wont be able to revert this"
 msgstr "Я підтверджую, що не зможу скасувати цю дію "
 
@@ -13517,8 +12004,6 @@ msgstr "Потрібна дія"
 msgid "Select All Columns"
 msgstr "Вибрати всі стовпці"
 
-#, fuzzy
-#| msgid "Save and add another"
 msgid "Save And Add Another"
 msgstr "Зберегти й додати ще"
 
@@ -13528,116 +12013,84 @@ msgstr "Записи"
 msgid "Assign Leave"
 msgstr "Призначити відпустку"
 
-#, fuzzy
-#| msgid "No records available at the moment."
 msgid "No filtered records found at the moment"
-msgstr "Наразі немає доступних записів."
+msgstr "Наразі відфільтрованих записів не знайдено"
 
 msgid "→"
-msgstr ""
+msgstr "→"
 
-#, fuzzy
-#| msgid "Restore the previous state"
 msgid "Restore previous state"
 msgstr "Відновити попередній стан"
 
 msgid "This will revert the object to a previous state."
-msgstr ""
+msgstr "Це поверне об'єкт до попереднього стану."
 
-#, fuzzy
-#| msgid "Reveal"
 msgid "Revert"
-msgstr "Розгорнути"
+msgstr "Скасувати"
 
-#, fuzzy
-#| msgid "Deleted:"
 msgid "Deleted"
 msgstr "Видалено:"
 
-#, fuzzy
-#| msgid "No notes have been added for this candidate."
 msgid "No history has been recorded for this record."
-msgstr "Для цього кандидата не додано жодної нотатки."
+msgstr "Для цього запису історії не зафіксовано."
 
 msgid "Settings"
 msgstr "Налаштування"
 
-#, fuzzy
-#| msgid "Encashment Settings"
 msgid "Account Settings"
-msgstr "Налаштування інкасації"
+msgstr "Налаштування акаунта"
 
-#, fuzzy
-#| msgid "Manage Tours"
 msgid "Manage Tabs"
-msgstr "Керуйте турами"
+msgstr "Керування вкладками"
 
-#, fuzzy
-#| msgid "Item"
 msgid "Items"
-msgstr "Елемент"
+msgstr "Елементи"
 
 msgid "Import Records"
 msgstr "Імпортувати записи"
 
-#, fuzzy
-#| msgid "Drag and drop files here"
 msgid "Click Here or Drag and drop your file here"
-msgstr "Перетягніть файли сюди"
+msgstr "Натисніть тут або перетягніть файл сюди"
 
 msgid "Show All"
 msgstr "Показати все"
 
 msgid "Enter a page number and press Enter"
-msgstr ""
+msgstr "Введіть номер сторінки й натисніть Enter"
 
 #, python-format
 msgid "Filter (%(counter)s)"
-msgstr ""
+msgstr "Фільтр (%(counter)s)"
 
-#, fuzzy
-#| msgid "Reject Requests"
 msgid "Reject request"
-msgstr "Відхилити запити"
+msgstr "Відхилити заявку"
 
 msgid "Deadline"
 msgstr "Кінцевий термін"
 
-#, fuzzy
-#| msgid "Last activity:"
 msgid "Last Activity"
 msgstr "Остання активність:"
 
-#, fuzzy
-#| msgid "Rotating shift assigned."
 msgid "No tags assigned"
-msgstr "Змінну зміну призначено."
+msgstr "Теги не призначені"
 
-#, fuzzy
-#| msgid "Forward to"
 msgid "Forwarded to"
-msgstr "Переспрямувати до"
+msgstr "Переспрямовано до"
 
 msgid "Choose or Drop Files Here"
-msgstr ""
+msgstr "Виберіть або перетягніть файли"
 
-#, fuzzy
-#| msgid "Update Ticket"
 msgid "Edit Ticket"
-msgstr "Оновити заявку"
+msgstr "Редагувати заявку"
 
-#, fuzzy
-#| msgid "Toggle Search"
 msgid "Toggle Rich Text"
-msgstr "Перемкнути пошук"
+msgstr "Перемкнути форматування"
 
-#, fuzzy
-#| msgid "Attachments"
 msgid "Add attachments"
-msgstr "Вкладення"
+msgstr "Додати вкладення"
 
 msgid "Write your message here..."
-msgstr ""
+msgstr "Напишіть повідомлення тут..."
 
 msgid "Send"
 msgstr "Надіслати"
@@ -13645,20 +12098,14 @@ msgstr "Надіслати"
 msgid "Do you want to delete the automation?"
 msgstr "Ви хочете видалити автоматизацію?"
 
-#, fuzzy
-#| msgid "Today's Attendances"
 msgid "Todays's New Joiners"
-msgstr "Сьогоднішня відвідуваність"
+msgstr "Нові співробітники сьогодні"
 
-#, fuzzy
-#| msgid "Leave days"
 msgid "Leave on today"
-msgstr "Дні відпустки"
+msgstr "Відпустка сьогодні"
 
-#, fuzzy
-#| msgid "New Joining This Week"
 msgid "Joining this week"
-msgstr "Нові співробітники цього тижня"
+msgstr "Приходять цього тижня"
 
 msgid "Total Strength"
 msgstr "Загальна чисельність"
@@ -13666,15 +12113,11 @@ msgstr "Загальна чисельність"
 msgid "Create Announcement"
 msgstr "Створити оголошення"
 
-#, fuzzy
-#| msgid "Shift Request to Approve"
 msgid "Shift Requests to Approve"
-msgstr "Запит на зміну зміни на затвердження"
+msgstr "Заявки на зміну до затвердження"
 
-#, fuzzy
-#| msgid "Work Type Request to Approve"
 msgid "Work Type Requests to Approve"
-msgstr "Запит на тип роботи на затвердження"
+msgstr "Заявки на тип роботи до затвердження"
 
 msgid "Employee Work Information"
 msgstr "Робоча інформація про співробітника"
@@ -13706,20 +12149,14 @@ msgstr "Запит на виділення відпустки для затве�
 msgid "Feedback To Answers"
 msgstr "Відгуки для відповіді"
 
-#, fuzzy
-#| msgid "No records available at the moment."
 msgid "No charts are available at the moment..."
-msgstr "Наразі немає доступних записів."
+msgstr "Наразі діаграм немає..."
 
-#, fuzzy
-#| msgid "Toggle auto-refresh"
 msgid "Toggle theme"
-msgstr "Увімкнути автоматичне оновлення"
+msgstr "Перемкнути тему"
 
-#, fuzzy
-#| msgid "Take An Action"
 msgid "Take a tour"
-msgstr "Вжити захід"
+msgstr "Пройти тур"
 
 msgid "All Notifications"
 msgstr "Усі сповіщення"
@@ -13727,24 +12164,20 @@ msgstr "Усі сповіщення"
 msgid "Clear All"
 msgstr "Очистити все"
 
-#, fuzzy
-#| msgid "Dashboard Charts"
 msgid "Reorder Dashboard Charts"
-msgstr "Діаграми панелі керування"
+msgstr "Змінити порядок діаграм дашборду"
 
 msgid "Lock sidebar open"
-msgstr ""
+msgstr "Закріпити бічну панель"
 
 msgid "Unlock sidebar (auto-collapses on hover-out)"
-msgstr ""
+msgstr "Відкріпити бічну панель (автоматично згортається)"
 
 msgid "My Company"
 msgstr "Моя компанія"
 
-#, fuzzy
-#| msgid "Toggle navigation"
 msgid "Main navigation"
-msgstr "Перемкнути навігацію"
+msgstr "Основна навігація"
 
 msgid "Select all users"
 msgstr "Вибрати всіх користувачів"
@@ -13757,243 +12190,155 @@ msgstr ""
 "Цей тип відпустки використовуватиметься для призначення компенсаційних "
 "відпусток."
 
-#, fuzzy
-#| msgid "leave-dashboard"
 msgid "Leave Dashboard"
 msgstr "дашборд відпусток"
 
-#, fuzzy
-#| msgid "Leave Request"
 msgid "Leave Request Trend"
-msgstr "Заявка на відпустку"
+msgstr "Тенденція заявок на відпустку"
 
 msgid "Approved, rejected & pending — last 6 months"
-msgstr ""
+msgstr "Затверджено, відхилено й в очікуванні — останні 6 місяців"
 
-#, fuzzy
-#| msgid "Leave Type Condition"
 msgid "Leave Type Distribution"
-msgstr "Залишити тип Умова"
+msgstr "Розподіл типів відпусток"
 
-#, fuzzy
-#| msgid "Unpaid"
 msgid "Paid vs Unpaid"
-msgstr "Неоплачувана"
+msgstr "Оплачувані та неоплачувані"
 
-#, fuzzy
-#| msgid "Same Department"
 msgid "Leave by Department"
-msgstr "Той самий відділ"
+msgstr "Відпустки за відділами"
 
-#, fuzzy
-#| msgid "Leave Reset Date"
 msgid "Leave Day Pattern"
-msgstr "Дата скидання відпустки"
+msgstr "Схема днів відпустки"
 
 msgid "Most common leave days — last 3 months"
-msgstr ""
+msgstr "Найчастіші дні відпусток — останні 3 місяці"
 
-#, fuzzy
-#| msgid "Leave Unit"
 msgid "Leave Utilization"
-msgstr "Одиниця відпустки"
+msgstr "Використання відпусток"
 
 msgid "Used vs remaining by leave type — all employees"
-msgstr ""
+msgstr "Використано та залишилось за типами відпусток — усі співробітники"
 
-#, fuzzy
-#| msgid "Upcoming Interview"
 msgid "Upcoming Leaves"
-msgstr "Майбутня співбесіда"
+msgstr "Найближчі відпустки"
 
-#, fuzzy
-#| msgid "Next Holiday"
 msgid "Next 7 days"
-msgstr "Наступне свято"
+msgstr "Наступні 7 днів"
 
-#, fuzzy
-#| msgid "Total Leave taken"
 msgid "Top Leave Takers"
-msgstr "Всього використано відпустки"
+msgstr "Найбільше відпусток"
 
-#, fuzzy
-#| msgid "Upcoming holidays"
 msgid "Upcoming Holidays"
 msgstr "Найближчі свята"
 
-#, fuzzy
-#| msgid "Waiting Approval"
 msgid "Pending Approval"
 msgstr "Очікує затвердження"
 
-#, fuzzy
-#| msgid "Allocation"
 msgid "allocation req"
-msgstr "Розподіл"
+msgstr "заявка на розподіл"
 
-#, fuzzy
-#| msgid "Requests to Approve"
 msgid "Requests awaiting review"
-msgstr "Запити на затвердження"
+msgstr "Заявки очікують перегляду"
 
-#, fuzzy
-#| msgid "days"
 msgid "days used"
-msgstr "днів"
+msgstr "використано днів"
 
-#, fuzzy
-#| msgid "View requests"
 msgid "comp. requests"
-msgstr "Переглянути запити"
+msgstr "заявки на компенсацію"
 
-#, fuzzy
-#| msgid "Employees"
 msgid "Employees away"
-msgstr "Співробітники"
+msgstr "Співробітників відсутні"
 
-#, fuzzy
-#| msgid "Leave days"
 msgid "No leave data"
-msgstr "Дні відпустки"
+msgstr "Немає даних про відпустки"
 
 msgid "Unpaid"
 msgstr "Неоплачувана"
 
-#, fuzzy
-#| msgid "Leave days"
 msgid "Leave Days"
 msgstr "Дні відпустки"
 
-#, fuzzy
-#| msgid "Allocation"
 msgid "No allocation data"
-msgstr "Розподіл"
+msgstr "Немає даних про розподіл"
 
-#, fuzzy
-#| msgid "No employees have taken leave today."
 msgid "No one on leave today"
-msgstr "Сьогодні жоден співробітник не брав відпустку."
+msgstr "Сьогодні ніхто не у відпустці"
 
-#, fuzzy
-#| msgid "Upcoming holidays"
 msgid "No upcoming leaves"
-msgstr "Найближчі свята"
+msgstr "Немає найближчих відпусток"
 
-#, fuzzy
-#| msgid "No leave request this month"
 msgid "No leaves this month"
-msgstr "Цього місяця немає заявок на відпустку"
+msgstr "Цього місяця немає відпусток"
 
-#, fuzzy
-#| msgid "requested"
 msgid "request(s)"
-msgstr "запитано"
+msgstr "заявка(и)"
 
-#, fuzzy
-#| msgid "Upcoming holidays"
 msgid "No upcoming holidays"
-msgstr "Найближчі свята"
+msgstr "Немає найближчих свят"
 
-#, fuzzy
-#| msgid "My Dashboard"
 msgid "My Leave Dashboard"
-msgstr "Моя інформаційна панель"
+msgstr "Мій дашборд відпусток"
 
-#, fuzzy
-#| msgid "View Admin Dashboard"
 msgid "Admin Dashboard"
-msgstr "Переглянути панель адміністратора"
+msgstr "Панель адміністратора"
 
-#, fuzzy
-#| msgid "Leave Trends"
 msgid "My Leave Trend"
-msgstr "Тенденції відпусток"
+msgstr "Тенденція моїх відпусток"
 
-#, fuzzy
-#| msgid "Restrict Leaves"
 msgid "Recent Leave History"
-msgstr "Обмежити відпустки"
+msgstr "Останні відпустки"
 
-#, fuzzy
-#| msgid "'s leave request"
 msgid "Your latest leave requests"
-msgstr " запит на відпустку"
+msgstr "Ваші останні заявки на відпустку"
 
-#, fuzzy
-#| msgid "View all comments"
 msgid "View all →"
-msgstr "Переглянути всі коментарі"
+msgstr "Дивитися всі →"
 
-#, fuzzy
-#| msgid "Upcoming Interview"
 msgid "My Upcoming Leaves"
-msgstr "Майбутня співбесіда"
+msgstr "Мої найближчі відпустки"
 
-#, fuzzy
-#| msgid "Export Leaves"
 msgid "Apply for Leave"
-msgstr "Експортувати відпустки"
+msgstr "Оформити відпустку"
 
-#, fuzzy
-#| msgid "View requests"
 msgid "View All Requests"
-msgstr "Переглянути запити"
+msgstr "Переглянути всі заявки"
 
-#, fuzzy
-#| msgid "Leave Allocation Request"
 msgid "Leave Allocation"
-msgstr "Запит на нарахування відпустки"
+msgstr "Нарахування відпустки"
 
-#, fuzzy
-#| msgid "Image Preview"
 msgid "Awaiting review"
-msgstr "Попередній перегляд зображення"
+msgstr "Очікує перегляду"
 
-#, fuzzy
-#| msgid "Total leaves available"
 msgid "Total leave balance"
-msgstr "Усього доступно днів відпустки"
+msgstr "Загальний баланс відпусток"
 
-#, fuzzy
-#| msgid "Approved By"
 msgid "Approved & ahead"
-msgstr "Затверджено"
+msgstr "Затверджено й попереду"
 
 msgid "Could not load data. Please refresh."
-msgstr ""
+msgstr "Не вдалося завантажити дані. Оновіть сторінку."
 
-#, fuzzy
-#| msgid "No feedbacks are available."
 msgid "No leave balance available"
-msgstr "Немає доступних відгуків."
+msgstr "Баланс відпустки недоступний"
 
-#, fuzzy
-#| msgid "Contract end date"
 msgid "No trend data"
-msgstr "Дата закінчення контракту"
+msgstr "Немає даних тенденції"
 
-#, fuzzy
-#| msgid "An approved leave exists"
 msgid "No upcoming approved leaves"
-msgstr "Існує затверджена відпустка"
+msgstr "Немає найближчих затверджених відпусток"
 
-#, fuzzy
-#| msgid "No leave request this month"
 msgid "No leave requests yet"
-msgstr "Цього місяця немає заявок на відпустку"
+msgstr "Заявок на відпустку ще немає"
 
-#, fuzzy
-#| msgid "Add Comment"
 msgid "Add Comments"
-msgstr "Додати коментар"
+msgstr "Додати коментарі"
 
 msgid "'s leave allocation request"
 msgstr " запит на нарахування відпустки"
 
-#, fuzzy
-#| msgid "No notes have been added for this employee"
 msgid "No Comments have been added for this Leave Allocation Request"
-msgstr "Для цього працівника не додано жодних приміток"
+msgstr "До цієї заявки на нарахування відпустки коментарів не додано"
 
 msgid "Requested Days"
 msgstr "Запитано днів"
@@ -14004,10 +12349,8 @@ msgstr "У вас немає запитів на відпустку за цей 
 msgid "'s leave request"
 msgstr " запит на відпустку"
 
-#, fuzzy
-#| msgid "No notes have been added for this employee"
 msgid "No Comments have been added for this Leave request"
-msgstr "Для цього працівника не додано жодних приміток"
+msgstr "До цієї заявки на відпустку коментарів не додано"
 
 msgid "Create Leave Type"
 msgstr "Створити тип відпустки"
@@ -14039,10 +12382,8 @@ msgstr "День скидання"
 msgid "Reset Weekday"
 msgstr "День тижня скидання"
 
-#, fuzzy
-#| msgid "Reset Day"
 msgid "Custom Reset Days"
-msgstr "День скидання"
+msgstr "Власні дні скидання"
 
 msgid "Custom reset interval in days"
 msgstr "Інтервал індивідуального скидання в днях"
@@ -14084,10 +12425,8 @@ msgstr ""
 msgid "Icon"
 msgstr "Іконка"
 
-#, fuzzy
-#| msgid "---Choose Action---"
 msgid "Choose Icon"
-msgstr "---Виберіть дію---"
+msgstr "Виберіть іконку"
 
 msgid "Require Approval"
 msgstr "Потребує затвердження"
@@ -14110,29 +12449,23 @@ msgstr "Оновити тип відпустки"
 msgid "Do you need to encash pending leave days?"
 msgstr "Потрібно виплачувати компенсацію за невикористані дні відпустки?"
 
-#, fuzzy
-#| msgid "Carryforward Leave Days"
 msgid "Carryforwrad Leave Days"
-msgstr "Дні відпустки, що переносяться"
+msgstr "Перенесені дні відпустки"
 
-#, fuzzy
-#| msgid "Total Leave taken"
 msgid "Total Leave Taken"
 msgstr "Всього використано відпустки"
 
-#, fuzzy
-#| msgid "Welcome,"
 msgid "Welcome to"
-msgstr "Вітаємо,"
+msgstr "Вітаємо в"
 
 msgid "HR"
-msgstr ""
+msgstr "HR"
 
 msgid "Please login to access the dashboard."
 msgstr "Будь ласка, увійдіть для доступу до панелі приладів."
 
 msgid "e.g. adam.luis@horilla.com"
-msgstr ""
+msgstr "напр. adam.luis@horilla.com"
 
 msgid "Sign In"
 msgstr "Вхід"
@@ -14143,18 +12476,12 @@ msgstr "Ініціалізувати базу даних"
 msgid "Load Demo Data"
 msgstr "Завантажити демо-дані"
 
-#, fuzzy
-#| msgid "ago by"
 msgid "ago by "
 msgstr "тому від"
 
-#, fuzzy
-#| msgid "All caught up!"
 msgid "All Caught Up!"
 msgstr "Усе оброблено!"
 
-#, fuzzy
-#| msgid "You have no new notifications at the moment."
 msgid "You have no new notifications at the moment"
 msgstr "Наразі у вас немає нових сповіщень."
 
@@ -14164,18 +12491,12 @@ msgstr "Сповіщення"
 msgid "Notification Sound"
 msgstr "Звук сповіщення"
 
-#, fuzzy
-#| msgid "Mark as read"
 msgid "Mark All as Read"
-msgstr "Позначити як прочитане"
+msgstr "Позначити все прочитаним"
 
-#, fuzzy
-#| msgid "All Notifications"
 msgid "Clear Notifications"
-msgstr "Усі сповіщення"
+msgstr "Очистити сповіщення"
 
-#, fuzzy
-#| msgid "View all notifications"
 msgid "View all Notification"
 msgstr "Переглянути всі сповіщення"
 
@@ -14209,15 +12530,11 @@ msgstr "Не повернені активи"
 msgid "Offboarding Employees Feedbacks"
 msgstr "Відгуки співробітників, що звільняються"
 
-#, fuzzy
-#| msgid "Note"
 msgid "'s Note"
-msgstr "Примітка"
+msgstr " — нотатка"
 
-#, fuzzy
-#| msgid "No notes have been added for this candidate"
 msgid "No Comments have been added for this Shift request"
-msgstr "Для цього кандидата не додано жодної нотатки"
+msgstr "До цієї заявки на зміну коментарів не додано"
 
 msgid "Resignation Request"
 msgstr "Заява на звільнення"
@@ -14241,7 +12558,7 @@ msgid "Do you want to delete this employee objective?"
 msgstr "Ви бажаєте видалити цю ціль співробітника?"
 
 msgid "Albert Camus"
-msgstr ""
+msgstr "Альбер Камю"
 
 msgid "updated"
 msgstr "оновлено"
@@ -14258,18 +12575,14 @@ msgstr "ключовий результат"
 msgid "added a comment"
 msgstr "додав(ла) коментар"
 
-#, fuzzy
-#| msgid "Update Objectives"
 msgid "updated objective details"
-msgstr "Оновити цілі"
+msgstr "деталі цілі оновлено"
 
 msgid "There are no assignees for this objective at the moment."
 msgstr "Наразі для цієї цілі немає виконавців."
 
-#, fuzzy
-#| msgid "Employee tag"
 msgid "Employee Onboarding"
-msgstr "Тег співробітника"
+msgstr "Адаптація співробітника"
 
 msgid "Login"
 msgstr "Вхід"
@@ -14301,10 +12614,8 @@ msgstr "Номер екстреного контакту"
 msgid "Next Step"
 msgstr "Наступний крок"
 
-#, fuzzy
-#| msgid "Task not found."
 msgid "No Tasks found."
-msgstr "Завдання не знайдено."
+msgstr "Завдань не знайдено."
 
 msgid "Complete Profile"
 msgstr "Заповнити профіль"
@@ -14318,169 +12629,119 @@ msgstr "Фото користувача"
 msgid "Authentication"
 msgstr "Автентифікація"
 
-#, fuzzy
-#| msgid "Welcome Aboard"
 msgid "Welcome Aboard!"
 msgstr "Ласкаво просимо до команди"
 
 msgid "Hey there, welcome to our team. Let's get you started."
-msgstr ""
+msgstr "Вітаємо в нашій команді. Давайте почнемо."
 
 msgid "Zoom in"
-msgstr ""
+msgstr "Збільшити"
 
-#, fuzzy
-#| msgid "Log out"
 msgid "Zoom out"
-msgstr "Вийти"
+msgstr "Зменшити"
 
 msgid "Pan up"
-msgstr ""
+msgstr "Прокрутити вгору"
 
 msgid "Pan left"
-msgstr ""
+msgstr "Прокрутити ліворуч"
 
 msgid "Pan right"
-msgstr ""
+msgstr "Прокрутити праворуч"
 
 msgid "Pan down"
-msgstr ""
+msgstr "Прокрутити вниз"
 
-#, fuzzy
-#| msgid "No Candidates available."
 msgid "No organization data available"
-msgstr "Немає доступних кандидатів."
+msgstr "Немає даних про організацію"
 
-#, fuzzy
-#| msgid "My Dashboard"
 msgid "Payroll Dashboard"
-msgstr "Моя інформаційна панель"
+msgstr "Дашборд зарплати"
 
-#, fuzzy
-#| msgid "Payslip deleted"
 msgid "Payslip Pipeline"
-msgstr "Розрахунковий лист видалено"
+msgstr "Воронка розрахункових листків"
 
 msgid "Current month — status distribution"
-msgstr ""
+msgstr "Поточний місяць — розподіл за статусом"
 
-#, fuzzy
-#| msgid "Payroll Records"
 msgid "Payroll Cost Trend"
-msgstr "Записи по заробітній платі"
+msgstr "Тенденція витрат на зарплату"
 
 msgid "Gross, deductions & net — last 6 months"
-msgstr ""
+msgstr "Брутто, утримання та до виплати — останні 6 місяців"
 
-#, fuzzy
-#| msgid "Department"
 msgid "Cost by Department"
-msgstr "Відділ"
+msgstr "Витрати за відділами"
 
 msgid "Reimbursements"
 msgstr "Компенсації витрат"
 
-#, fuzzy
-#| msgid "Requests cannot be made for past dates."
 msgid "Requests by type and status"
-msgstr "Заявки не можна подавати на минулі дати."
+msgstr "Заявки за типом і статусом"
 
-#, fuzzy
-#| msgid "Employee Contribution"
 msgid "Salary Distribution"
-msgstr "Внесок співробітника"
+msgstr "Розподіл зарплат"
 
-#, fuzzy
-#| msgid "Employee Netpay :"
 msgid "Employee count by pay band"
-msgstr "Чистий дохід співробітника:"
+msgstr "Кількість співробітників за рівнем оплати"
 
-#, fuzzy
-#| msgid "Deduction not found"
 msgid "Deduction Components"
-msgstr "Утримання не знайдено"
+msgstr "Складові утримання"
 
 msgid "Top components this period"
-msgstr ""
+msgstr "Топ складових за період"
 
 msgid "Top Earners"
-msgstr ""
+msgstr "Найвищі виплати"
 
-#, fuzzy
-#| msgid "Contracts ending "
 msgid "Contracts Ending"
 msgstr "Завершення контрактів "
 
-#, fuzzy
-#| msgid "Actions"
 msgid "Active Loans"
-msgstr "Дії"
+msgstr "Активні позики"
 
-#, fuzzy
-#| msgid "Payroll"
 msgid "Net Payroll"
-msgstr "Заробітна плата"
+msgstr "До виплати"
 
-#, fuzzy
-#| msgid "st day of month"
 msgid "vs last month"
-msgstr "-й день місяця"
+msgstr "проти минулого місяця"
 
 msgid "payslips"
 msgstr "розрахункові листки"
 
-#, fuzzy
-#| msgid "Total"
 msgid "total"
 msgstr "Усього"
 
-#, fuzzy
-#| msgid "My actions"
 msgid "No active loans"
-msgstr " Дії"
+msgstr "Немає активних позик"
 
-#, fuzzy
-#| msgid "Pending Leaves Requests"
 msgid "Pending requests"
-msgstr "Запити на відпустку в очікуванні"
+msgstr "заявки в очікуванні"
 
-#, fuzzy
-#| msgid "No payslips generated for this month."
 msgid "No payslips this month"
-msgstr "За цей місяць розрахункові листи не сформовано."
+msgstr "Цього місяця немає розрахункових листків"
 
-#, fuzzy
-#| msgid "payroll"
 msgid "No payroll data"
-msgstr "нарахування зарплати"
+msgstr "Немає даних зарплати"
 
-#, fuzzy
-#| msgid "Gross Pay"
 msgid "Gross"
-msgstr "Валова заробітна плата"
+msgstr "Брутто"
 
-#, fuzzy
-#| msgid "Next"
 msgid "Net"
-msgstr "Наступна"
+msgstr "До виплати"
 
-#, fuzzy
-#| msgid "Reimbursements"
 msgid "No reimbursements"
-msgstr "Компенсації витрат"
+msgstr "Немає компенсацій"
 
-#, fuzzy
-#| msgid "Total Leave Requests"
 msgid "Total requests"
-msgstr "Загальна кількість запитів на відпустку"
+msgstr "Усього заявок"
 
 msgid "No salary data"
-msgstr ""
+msgstr "Немає даних про зарплату"
 
-#, fuzzy
-#| msgid "No contracts ending this month"
 msgid "No contracts ending soon"
-msgstr "Контрактів, що завершуються цього місяця, немає"
+msgstr "Немає контрактів, що спливають"
 
 msgid "Employee Contribution"
 msgstr "Внесок співробітника"
@@ -14536,10 +12797,8 @@ msgstr "Оплачені дні"
 msgid "LOP Days"
 msgstr "Дні LOP"
 
-#, fuzzy
-#| msgid "Paid Days"
 msgid "Partially Paid Days"
-msgstr "Оплачені дні"
+msgstr "Частково оплачені дні"
 
 msgid "Updated Basic Pay"
 msgstr "Оновлена базова оплата"
@@ -14550,18 +12809,14 @@ msgstr "Розрахунковий листок обчислюється на о
 msgid "Taxable Gross Pay"
 msgstr "Оподатковувана валова заробітна плата"
 
-#, fuzzy
-#| msgid "taxable amount"
 msgid "Taxable amount"
 msgstr "сума, що оподатковується"
 
 msgid "Employee Details"
 msgstr "Дані співробітника"
 
-#, fuzzy
-#| msgid "Bank Acc./Cheque No."
 msgid "Bank Acc."
-msgstr "Банк. рахунок/номер чека"
+msgstr "Банк. рахунок"
 
 msgid "Add Allowance"
 msgstr "Додати надбавку"
@@ -14596,16 +12851,16 @@ msgstr "Додати утримання"
 msgid "Loss of Pay"
 msgstr "Втрата оплати"
 
-#, fuzzy
-#| msgid "Net Pay Deductions"
 msgid "Leave Payment Reduction"
-msgstr "Утримання з чистого доходу"
+msgstr "Зменшення оплати за відпустку"
 
 #, python-format
 msgid ""
 "Partial deduction — %(partial_pay_days)s\n"
 "                            day(s) on a partially paid leave type"
 msgstr ""
+"Часткове утримання — %(partial_pay_days)s\n"
+"                            дн. за типом відпустки з частковою оплатою"
 
 msgid "Basic Pay Deductions"
 msgstr "Утримання з базової оплати"
@@ -14634,20 +12889,17 @@ msgstr ""
 "утримуються після обчислення чистого доходу."
 
 msgid "Custom Payment Leave Details"
-msgstr ""
+msgstr "Деталі відпустки з власною оплатою"
 
-#, fuzzy, python-format
-#| msgid "Payment"
+#, python-format
 msgid "Payment %%"
-msgstr "Платіж"
+msgstr "Платіж %%"
 
 msgid "'s reimbursement request"
 msgstr "запит на компенсацію витрат"
 
-#, fuzzy
-#| msgid "No notes have been added for this employee"
 msgid "No Comments have been added for this reimbursement request"
-msgstr "Для цього працівника не додано жодних приміток"
+msgstr "До цієї заявки на компенсацію коментарів не додано"
 
 msgid "Symbol shown for monetary values (e.g. $, €)."
 msgstr "Символ для грошових значень (напр. $, €)."
@@ -14656,7 +12908,7 @@ msgid "Whether the symbol appears before (prefix) or after (suffix)."
 msgstr "Чи з’являється символ перед сумою (префікс) чи після (суфікс)."
 
 msgid "Company these currency settings apply to."
-msgstr ""
+msgstr "Компанія, до якої застосовуються ці налаштування валюти."
 
 msgid "Default Notice Period"
 msgstr "Типовий термін попередження"
@@ -14679,51 +12931,43 @@ msgstr "Кандидата додано"
 msgid "Create Candidate"
 msgstr "Створити кандидата"
 
-#, fuzzy
-#| msgid "Add notes"
 msgid "Add a note"
-msgstr "Додати примітки"
+msgstr "Додати нотатку"
 
 msgid "Example: Candidate requested interview reschedule to Friday 3 PM."
-msgstr ""
+msgstr "Приклад: кандидат попросив перенести співбесіду на п'ятницю 15:00."
 
 msgid "Type your update, then click Add note."
-msgstr ""
+msgstr "Введіть оновлення й натисніть «Додати нотатку»."
 
-#, fuzzy
-#| msgid "Add notes"
 msgid "Add note"
-msgstr "Додати примітки"
+msgstr "Додати нотатку"
 
 msgid "At"
-msgstr ""
+msgstr "в"
 
 msgid "Candidate can view this note"
 msgstr "Кандидат може переглядати цю примітку"
 
-#, fuzzy
-#| msgid "Candidate can"
 msgid "Candidate can\\"
-msgstr "Кандидат може"
+msgstr "Кандидат може\\"
 
 msgid ""
 "No notes yet. Use the 'Add a note' field above to save interview updates."
-msgstr ""
+msgstr "Нотаток ще немає. Скористайтеся полем «Додати нотатку» вище."
 
-#, fuzzy
-#| msgid "There is no disciplinary action type at this moment."
 msgid ""
 "Define disciplinary action types used when recording employee incidents."
-msgstr "Наразі немає типів дисциплінарних стягнень."
+msgstr ""
+"Визначте типи дисциплінарних дій для фіксації інцидентів співробітників."
 
 msgid "Record and track disciplinary incidents for employees."
-msgstr ""
+msgstr "Фіксуйте й відстежуйте дисциплінарні інциденти співробітників."
 
 msgid "Create and manage company policies shared with employees."
 msgstr ""
+"Створюйте й керуйте політиками компанії, спільними для співробітників."
 
-#, fuzzy
-#| msgid "View policy"
 msgid "View Policy"
 msgstr "Переглянути політику"
 
@@ -14749,10 +12993,8 @@ msgstr "Місткість"
 msgid "Total vacancies"
 msgstr "Всього вакансій"
 
-#, fuzzy
-#| msgid "Recruitments"
 msgid "Recruitment Details"
-msgstr "Підбір персоналу"
+msgstr "Деталі вакансії"
 
 msgid "Job positions :"
 msgstr "Посади:"
@@ -14780,10 +13022,8 @@ msgstr ""
 "Увімкнення цієї функції дозволяє кандидатам бачити свій загальний рейтинг у "
 "наборі"
 
-#, fuzzy
-#| msgid "Replace Employee"
 msgid "Replace"
-msgstr "Замінити співробітника"
+msgstr "Замінити"
 
 msgid "Asset Reports"
 msgstr "Звіти по активах"
@@ -14792,177 +13032,126 @@ msgid "Filters"
 msgstr "Фільтри"
 
 msgid "Expand"
-msgstr ""
+msgstr "Розгорнути"
 
-#, fuzzy
-#| msgid "Add more shift.."
 msgid "Add more filter"
-msgstr "Додати ще зміну.."
+msgstr "Додати ще фільтр"
 
-#, fuzzy
-#| msgid "Clear Filter"
 msgid "Applied Filters"
-msgstr "Очистити фільтр"
+msgstr "Застосовані фільтри"
 
-#, fuzzy
-#| msgid "Template"
 msgid "Template name"
-msgstr "Шаблон"
+msgstr "Назва шаблону"
 
 msgid "Save Current Arrangement"
-msgstr ""
+msgstr "Зберегти поточне розташування"
 
-#, fuzzy
-#| msgid "No documents have been uploaded yet."
 msgid "No saved templates yet."
-msgstr "Документи ще не завантажено."
+msgstr "Збережених шаблонів ще немає."
 
 msgid "Export Table"
 msgstr "Експортувати таблицю"
 
 msgid "As PDF"
-msgstr ""
+msgstr "Як PDF"
 
 msgid "As Excel"
-msgstr ""
+msgstr "Як Excel"
 
 msgid "As CSV"
-msgstr ""
+msgstr "Як CSV"
 
-#, fuzzy
-#| msgid "View FAQs"
 msgid "View As"
-msgstr "Переглянути FAQ"
+msgstr "Дивитися як"
 
 msgid ""
 "Drag fields between the boxes below to change how this report is grouped."
 msgstr ""
+"Перетягуйте поля між блоками нижче, щоб змінити групування цього звіту."
 
-#, fuzzy
-#| msgid "Do you want to delete this template"
 msgid "Delete this saved template?"
-msgstr "Бажаєте видалити цей шаблон"
+msgstr "Видалити цей збережений шаблон?"
 
-#, fuzzy
-#| msgid "Please enter different name"
 msgid "Please enter a template name."
-msgstr "Будь ласка, введіть інше ім'я"
+msgstr "Введіть назву шаблону."
 
-#, fuzzy
-#| msgid "Nothing to reject."
 msgid "Nothing to save yet."
-msgstr "Нічого відхилити."
+msgstr "Поки нічого зберігати."
 
 msgid "Click to expand or collapse"
-msgstr ""
+msgstr "Натисніть, щоб розгорнути або згорнути"
 
-#, fuzzy
-#| msgid "Available days"
 msgid "Available Fields"
-msgstr "Доступні дні"
+msgstr "Доступні поля"
 
 msgid "Rows"
-msgstr ""
+msgstr "Рядки"
 
-#, fuzzy
-#| msgid "Total"
 msgid "Totals"
-msgstr "Усього"
+msgstr "Разом"
 
-#, fuzzy
-#| msgid "Clear Filter"
 msgid "Applied Filters: "
-msgstr "Очистити фільтр"
+msgstr "Застосовані фільтри: "
 
-#, fuzzy
-#| msgid "Assets In Use"
 msgid "Asset User"
-msgstr "Активи в користуванні"
+msgstr "Користувач активу"
 
-#, fuzzy
-#| msgid "Asset fine added"
 msgid "Asset User Badge Id"
-msgstr "Штраф за актив додано"
+msgstr "Бейдж користувача активу"
 
-#, fuzzy
-#| msgid "equals"
 msgid "Equals"
 msgstr "дорівнює"
 
-#, fuzzy
-#| msgid "Not Equal (!=)"
 msgid "Not Equals"
-msgstr "Не дорівнює (!=)"
+msgstr "Не дорівнює"
 
-#, fuzzy
-#| msgid "Empty"
 msgid "Is Empty"
-msgstr "Порожньо"
+msgstr "Порожнє"
 
-#, fuzzy
-#| msgid "Greater Than (>)"
 msgid "Greater Than"
-msgstr "Більше ніж (>)"
+msgstr "Більше ніж"
 
-#, fuzzy
-#| msgid "Less Than (<)"
 msgid "Less Than"
-msgstr "Менше ніж (<)"
+msgstr "Менше ніж"
 
 msgid "Between"
-msgstr ""
+msgstr "Між"
 
-#, fuzzy
-#| msgid "Notify Before"
 msgid "Before"
-msgstr "Повідомити заздалегідь"
+msgstr "До"
 
 msgid "Yesterday"
 msgstr "Вчора"
 
-#, fuzzy
-#| msgid "First Week"
 msgid "Last Week"
-msgstr "Перший тиждень"
+msgstr "Минулий тиждень"
 
-#, fuzzy
-#| msgid "Last Day"
 msgid "Last Year"
-msgstr "Останній день"
+msgstr "Минулий рік"
 
-#, fuzzy
-#| msgid "Selected"
 msgid "Select Field"
-msgstr "Вибрано"
+msgstr "Виберіть поле"
 
-#, fuzzy
-#| msgid "Select Date Format:"
 msgid "Select Operator"
-msgstr "Оберіть формат дати:"
+msgstr "Виберіть оператор"
 
-#, fuzzy
-#| msgid "Select Date Format:"
 msgid "Select one or more"
-msgstr "Оберіть формат дати:"
+msgstr "Виберіть один або кілька"
 
 msgid "OR"
-msgstr ""
+msgstr "АБО"
 
 msgid "AND"
-msgstr ""
+msgstr "І"
 
 msgid "Click to toggle AND/OR"
-msgstr ""
+msgstr "Натисніть, щоб перемкнути І/АБО"
 
-#, fuzzy
-#| msgid "Enter a title"
 msgid "Enter value"
-msgstr "Введіть назву"
+msgstr "Введіть значення"
 
-#, fuzzy
-#| msgid "Not validated"
 msgid "No value needed"
-msgstr "Не підтверджено"
+msgstr "Значення не потрібне"
 
 msgid "Attendance Reports"
 msgstr "Звіти по відвідуваності"
@@ -14985,10 +13174,8 @@ msgstr "Обрати звіт"
 msgid "Available Leave"
 msgstr "Доступна відпустка"
 
-#, fuzzy
-#| msgid "Available Leaves"
 msgid "Available Leave Reports"
-msgstr "Доступні відпустки"
+msgstr "Звіти по доступних відпустках"
 
 msgid "Start Date Breakdown"
 msgstr "Розбивка початкової дати"
@@ -14999,15 +13186,11 @@ msgstr "Розбивка кінцевої дати"
 msgid "Carryforward Days"
 msgstr "Днів перенесено"
 
-#, fuzzy
-#| msgid "Reset Day"
 msgid "Reset Date"
-msgstr "День скидання"
+msgstr "Дата скидання"
 
-#, fuzzy
-#| msgid "Expiry Date"
 msgid "Expired Date"
-msgstr "Термін дії до"
+msgstr "Дата закінчення"
 
 msgid "Payroll Reports"
 msgstr "Звіти по заробітній платі"
@@ -15015,10 +13198,8 @@ msgstr "Звіти по заробітній платі"
 msgid "Allowance & Deduction"
 msgstr "Надбавки та відрахування"
 
-#, fuzzy
-#| msgid "Allowance & Deduction"
 msgid "Allowance & Deduction Reports"
-msgstr "Надбавки та відрахування"
+msgstr "Звіти по надбавках і утриманнях"
 
 msgid "Contract Wage"
 msgstr "Оплата за контрактом"
@@ -15035,48 +13216,32 @@ msgstr "Ціль співробітника"
 msgid "Feedback"
 msgstr "Відгук"
 
-#, fuzzy
-#| msgid "Employee Objectives"
 msgid "Employee Objective Reports"
-msgstr "Цілі співробітника"
+msgstr "Звіти по цілях співробітників"
 
-#, fuzzy
-#| msgid "Feedback Answers"
 msgid "Feedback Reports"
-msgstr "Відповіді на відгук"
+msgstr "Звіти по відгуках"
 
-#, fuzzy
-#| msgid "Badge Id"
 msgid "Manager Badge Id"
-msgstr "Ідентифікатор бейджа"
+msgstr "Бейдж керівника"
 
-#, fuzzy
-#| msgid "Assigned Date"
 msgid "Assignee Badge Id"
-msgstr "Дата призначення"
+msgstr "Бейдж виконавця"
 
-#, fuzzy
-#| msgid "Assigned Date"
 msgid "Assignee Department"
-msgstr "Дата призначення"
+msgstr "Відділ виконавця"
 
-#, fuzzy
-#| msgid "Choose Job Position"
 msgid "Assignee Job Position"
-msgstr "Виберіть посаду"
+msgstr "Посада виконавця"
 
-#, fuzzy
-#| msgid "Assigned To"
 msgid "Assignee Job Role"
-msgstr "Призначено"
+msgstr "Роль виконавця"
 
 msgid "Feedback Title"
 msgstr "Назва відгуку"
 
-#, fuzzy
-#| msgid "Employee saved"
 msgid "Employee Badge Id"
-msgstr "Співробітника збережено"
+msgstr "Бейдж співробітника"
 
 msgid "Subordinate"
 msgstr "Підлеглий"
@@ -15096,18 +13261,12 @@ msgstr "Кандидат"
 msgid "Onboarding"
 msgstr "Адаптація"
 
-#, fuzzy
-#| msgid "recruitment-report"
 msgid "Recruitment Reports"
-msgstr "звіт з підбору персоналу"
+msgstr "Звіти по підбору"
 
-#, fuzzy
-#| msgid "Onboarding portal"
 msgid "Onboarding Reports"
-msgstr "Портал адаптації"
+msgstr "Звіти по адаптації"
 
-#, fuzzy
-#| msgid "Date of Birth"
 msgid "Date Of Birth"
 msgstr "Дата народження"
 
@@ -15123,10 +13282,8 @@ msgstr "Тип етапу"
 msgid "Is Canceled"
 msgstr "Скасовано"
 
-#, fuzzy
-#| msgid "Recruitments"
 msgid "Recruitment Status"
-msgstr "Підбір персоналу"
+msgstr "Статус підбору"
 
 msgid "Vacancy"
 msgstr "Вакансія"
@@ -15146,34 +13303,32 @@ msgstr "Завдання"
 msgid "Stage Manager"
 msgstr "Менеджер етапу"
 
-#, fuzzy
-#| msgid "Stage Manager"
 msgid "Stage Manager Badge Id"
-msgstr "Менеджер етапу"
+msgstr "Бейдж менеджера етапу"
 
 msgid "Task Manager"
 msgstr "Диспетчер завдань"
 
-#, fuzzy
-#| msgid "Task Manager"
 msgid "Task Manager Badge Id"
-msgstr "Диспетчер завдань"
+msgstr "Бейдж керівника завдання"
 
 msgid "Candidates"
 msgstr "Кандидати"
 
 msgid "Review document upload requests and submit required files from HR."
 msgstr ""
+"Перегляньте запити на завантаження документів і надішліть потрібні файли від"
+" HR."
 
 msgid ""
 "Requests from colleagues asking you to cover or take over their shifts."
-msgstr ""
+msgstr "Заявки від колег із проханням підмінити або взяти їхні зміни."
 
 msgid "Submit and manage your shift change requests for approval."
-msgstr ""
+msgstr "Подавайте й відстежуйте свої заявки на зміну графіка."
 
 msgid "Submit and manage requests to change your work type assignment."
-msgstr ""
+msgstr "Подавайте й відстежуйте заявки на зміну свого типу роботи."
 
 msgid "Company-specific settings"
 msgstr "Налаштування для компанії"
@@ -15191,22 +13346,18 @@ msgstr ""
 msgid "Search settings…"
 msgstr "Пошук налаштувань…"
 
-#, fuzzy
-#| msgid "No penalties found"
 msgid "No settings found"
-msgstr "Штрафів не знайдено"
+msgstr "Налаштувань не знайдено"
 
-#, fuzzy
-#| msgid "Enable LinkedIn"
 msgid "Enable Linkedin"
 msgstr "Увімкніть LinkedIn"
 
 msgid "Enable this to integrate linkedin to Horilla."
-msgstr ""
+msgstr "Увімкніть, щоб інтегрувати LinkedIn у Horilla."
 
 msgid ""
 "Post job openings directly to LinkedIn and manage applicants from Horilla."
-msgstr ""
+msgstr "Публікуйте вакансії прямо в LinkedIn і керуйте відгуками з Horilla."
 
 msgid "Prefix added to every auto-generated employee badge ID (e.g. PEP0001)."
 msgstr ""
@@ -15217,8 +13368,6 @@ msgstr ""
 msgid "Do you want to archive this skill zone ?"
 msgstr "Бажаєте архівувати цю зону навичок?"
 
-#, fuzzy
-#| msgid "Do you want to un archive this skill zone?"
 msgid "Do you want to unarchive this skill zone?"
 msgstr "Бажаєте розархівувати цю зону навичок?"
 
@@ -15228,10 +13377,8 @@ msgstr "Ви впевнені, що хочете видалити цю зону 
 msgid "Added on"
 msgstr "Додано"
 
-#, fuzzy
-#| msgid "View requests"
 msgid "View resume"
-msgstr "Переглянути запити"
+msgstr "Переглянути резюме"
 
 msgid "Do you want to remove this candidate"
 msgstr "Бажаєте видалити цього кандидата"
@@ -15263,33 +13410,21 @@ msgstr "Шаблони опитувань"
 msgid "Create survey questions"
 msgstr "Створити питання опитування"
 
-#, fuzzy
-#| msgid "Please select any backup option."
 msgid "Please select one option"
-msgstr "Виберіть будь-який резервний варіант."
+msgstr "Виберіть один варіант"
 
-#, fuzzy
-#| msgid "Balance points to redeem:"
 msgid "Balance point(s) to redeem"
 msgstr "Балансові бали для обміну:"
 
-#, fuzzy
-#| msgid "Redeem Now"
 msgid "Redeem"
-msgstr "Обміняти зараз"
+msgstr "Обміняти"
 
-#, fuzzy
-#| msgid "Audit & History"
 msgid "Points History"
-msgstr "Аудит та історія"
+msgstr "Історія балів"
 
-#, fuzzy
-#| msgid "Bonus Account created"
 msgid "Bonus account Created"
 msgstr "Бонусний рахунок створено"
 
-#, fuzzy
-#| msgid "Title must be at least 3 characters"
 msgid "Title must be at least 3 characters."
 msgstr "Заголовок має містити щонайменше 3 символи"
 
@@ -15298,42 +13433,31 @@ msgid ""
 "Showing group permissions for %(company)s. Switch company to see permissions"
 " in another company."
 msgstr ""
+"Показано дозволи груп для %(company)s. Перемкніть компанію, щоб побачити "
+"дозволи в іншій."
 
 msgid "Showing combined group permissions across assigned companies."
-msgstr ""
+msgstr "Показано зведені дозволи груп у призначених компаніях."
 
-#, fuzzy, python-format
-#| msgid "No projects assigned to this employee."
+#, python-format
 msgid "No groups assigned for %(company)s."
-msgstr "Цьому співробітнику не призначено жодного проєкту."
+msgstr "Для %(company)s груп не призначено."
 
-#, fuzzy
-#| msgid "Basic Pay"
 msgid "Basic"
-msgstr "Базова оплата"
+msgstr "Базовий оклад"
 
-#, fuzzy
-#| msgid "Years"
 msgid "years"
 msgstr "Роки"
 
-#, fuzzy
-#| msgid "Emergency Contact"
 msgid "Emergency contact"
 msgstr "Контакт для екстрених випадків"
 
-#, fuzzy
-#| msgid "Contract name"
 msgid "Contact number"
-msgstr "Назва контракту"
+msgstr "Номер контакту"
 
-#, fuzzy
-#| msgid "Resignation"
 msgid "Relation"
-msgstr "Звільнення за власним бажанням"
+msgstr "Родинний зв'язок"
 
-#, fuzzy
-#| msgid "Current Shift"
 msgid "Current Shifeet"
 msgstr "Поточна зміна"
 
@@ -15352,37 +13476,29 @@ msgstr "Керівники завдання"
 msgid "No tasks found in this stage."
 msgstr "На цьому етапі завдань не знайдено."
 
-#, fuzzy
-#| msgid "Search in FAQs..."
 msgid "Search by Task Name..."
-msgstr "Пошук у поширених запитаннях..."
+msgstr "Пошук за назвою завдання..."
 
-#, fuzzy
-#| msgid "Active"
 msgid "(Active)"
 msgstr "Активний"
 
 msgid "Remove as default"
-msgstr ""
+msgstr "Прибрати як типове"
 
-#, fuzzy
-#| msgid "Default Grace Time"
 msgid "Default Theme"
-msgstr "Пільговий час за замовчуванням"
+msgstr "Тема за замовчуванням"
 
 msgid "Set as default for login page"
-msgstr ""
+msgstr "Зробити типовою для сторінки входу"
 
 msgid "Set as Default"
-msgstr ""
+msgstr "Зробити типовим"
 
-#, fuzzy
-#| msgid "Not available"
 msgid "No themes available"
-msgstr "Недоступний"
+msgstr "Немає доступних тем"
 
 msgid "Select a theme to customize the appearance of your application"
-msgstr ""
+msgstr "Виберіть тему, щоб налаштувати вигляд вашого застосунку"
 
 msgid "Personal Timesheet of"
 msgstr "Особистий табель обліку робочого часу"
@@ -15390,191 +13506,158 @@ msgstr "Особистий табель обліку робочого часу"
 msgid "Week"
 msgstr "Тиждень"
 
-#, fuzzy
-#| msgid "Shift Request"
 msgid "Shift Roster"
-msgstr "Запит на зміну"
+msgstr "Графік змін"
 
-#, fuzzy
-#| msgid "No notes have been added for this employee"
 msgid "No Comments have been added for this worktype request"
-msgstr "Для цього працівника не додано жодних приміток"
+msgstr "До цієї заявки на тип роботи коментарів не додано"
 
-#, fuzzy
-#| msgid "This field is required"
 msgid "Theme ID is required"
-msgstr "Це поле обов'язкове"
+msgstr "Потрібен ID теми"
 
-#, fuzzy
-#| msgid "No penalties found"
 msgid "No active company found"
-msgstr "Штрафів не знайдено"
+msgstr "Активної компанії не знайдено"
 
 msgid "Theme changed successfully and set as default for login page"
-msgstr ""
+msgstr "Тему успішно змінено й зроблено типовою для сторінки входу"
 
-#, fuzzy
-#| msgid "Username changed successfully"
 msgid "Theme changed successfully"
-msgstr "Ім'я користувача успішно змінено"
+msgstr "Тему успішно змінено"
 
-#, fuzzy
-#| msgid "Timesheet not found"
 msgid "Theme not found"
-msgstr "Табель не знайдено"
+msgstr "Тему не знайдено"
 
-#, fuzzy
-#| msgid "An error occurred while deleting the allowance"
 msgid "An error occurred while changing the theme"
-msgstr "Під час видалення надбавки сталася помилка"
+msgstr "Під час зміни теми сталася помилка"
 
 msgid "Theme removed as default for login page"
-msgstr ""
+msgstr "Тему прибрано як типову для сторінки входу"
 
 msgid "Theme set as default for login page"
-msgstr ""
+msgstr "Тему зроблено типовою для сторінки входу"
 
 msgid "Product Tours"
 msgstr "Продуктові тури"
 
 msgid "Everyone"
-msgstr ""
+msgstr "Усі"
 
 msgid "Admins / Superusers"
-msgstr ""
+msgstr "Адміни / суперюзери"
 
-#, fuzzy
-#| msgid "Reporting manager"
 msgid "Reporting managers"
-msgstr "Керівник"
+msgstr "Керівники за підпорядкуванням"
 
-#, fuzzy
-#| msgid "Employee Tags"
 msgid "Employees (non-managers)"
-msgstr "Теги працівників"
+msgstr "Співробітники (не керівники)"
 
 msgid "Auto-start once, then on demand"
-msgstr ""
+msgstr "Автозапуск один раз, далі за потреби"
 
 msgid "Only from the Help launcher"
-msgstr ""
+msgstr "Лише з довідкового меню"
 
 msgid "URL name (exact)"
-msgstr ""
+msgstr "Назва URL (точна)"
 
 msgid "Path starts with"
-msgstr ""
+msgstr "Шлях починається з"
 
-#, fuzzy
-#| msgid "API Key"
 msgid "Key"
-msgstr "Ключ API"
+msgstr "Ключ"
 
 msgid "Stable identifier used in code/seed data, e.g. 'getting-started'."
-msgstr ""
+msgstr "Стабільний ідентифікатор для коду/сід-даних, напр. 'getting-started'."
 
 msgid ""
 "Where this tour applies. With 'URL name' enter the resolver name (e.g. "
 "'dashboard'); with 'Path starts with' enter a path prefix (e.g. "
 "'/employee/'). Leave blank to allow on any page."
 msgstr ""
+"Де застосовується цей тур. З «Назвою URL» вкажіть назву резолвера (напр. "
+"'dashboard'); з «Шлях починається з» — префікс шляху (напр. '/employee/'). "
+"Порожнє — на будь-якій сторінці."
 
-#, fuzzy
-#| msgid "Batch No"
 msgid "Match by"
-msgstr "Номер партії"
+msgstr "Зіставити за"
 
-#, fuzzy
-#| msgid "Sequence"
 msgid "Audience"
-msgstr "Послідовність"
+msgstr "Аудиторія"
 
 msgid "Unpublished tours are drafts and never shown to users."
-msgstr ""
+msgstr "Неопубліковані тури є чернетками й ніколи не показуються."
 
 msgid "Higher priority tours auto-start first when several match a page."
-msgstr ""
+msgstr "Тури з вищим приоритетом запускаються першими, якщо підходять кілька."
 
-#, fuzzy
-#| msgid "In progress"
 msgid "Show progress bar"
-msgstr "В процесі"
+msgstr "Показувати смугу прогресу"
 
-#, fuzzy
-#| msgid "Allowance"
 msgid "Allow close"
-msgstr "Надбавка"
+msgstr "Дозволити закриття"
 
 msgid "ion-icon name shown in the Help launcher."
-msgstr ""
+msgstr "Назва ion-icon, що показується в довідковому меню."
 
 msgid "Leave blank for a global tour shared by every company."
-msgstr ""
+msgstr "Залиште порожнім для глобального туру, спільного для всіх компаній."
 
 msgid "Tour"
-msgstr ""
+msgstr "Тур"
 
-#, fuzzy
-#| msgid "Hours"
 msgid "Tours"
-msgstr "Години"
+msgstr "Тури"
 
-#, fuzzy
-#| msgid "To"
 msgid "Top"
-msgstr "До"
+msgstr "Зверху"
 
 msgid "Bottom"
-msgstr ""
+msgstr "Знизу"
 
 msgid "Left"
-msgstr ""
+msgstr "Ліворуч"
 
 msgid "Right"
-msgstr ""
+msgstr "Праворуч"
 
-#, fuzzy
-#| msgid "Create Announcement"
 msgid "Center (no element)"
-msgstr "Створити оголошення"
+msgstr "По центру (без елемента)"
 
 msgid "Center"
-msgstr ""
+msgstr "По центру"
 
 msgid "End"
 msgstr "Кінець"
 
 msgid "Order"
-msgstr ""
+msgstr "Порядок"
 
-#, fuzzy
-#| msgid "Clear selection"
 msgid "Element selector"
-msgstr "Очистити вибір"
+msgstr "Селектор елемента"
 
 msgid ""
 "CSS selector of the element to highlight (e.g. '#notificationIcon'). Leave "
 "blank for a centered message step."
 msgstr ""
+"CSS-селектор елемента для підсвічування (напр. '#notificationIcon'). Порожнє"
+" — крок із центрованим повідомленням."
 
 msgid "Align"
-msgstr ""
+msgstr "Вирівнювання"
 
 msgid "Step page"
-msgstr ""
+msgstr "Сторінка кроку"
 
 msgid ""
 "Optional: for multi-page tours, the URL name this step lives on. Leave blank"
 " to use the tour's page."
 msgstr ""
+"Необов'язково: для багатосторінкових турів — назва URL, де живе цей крок. "
+"Порожнє — сторінка туру."
 
-#, fuzzy
-#| msgid "Tour Steps"
 msgid "Tour step"
-msgstr "Кроки туру"
+msgstr "Крок туру"
 
-#, fuzzy
-#| msgid "Tour Steps"
 msgid "Tour steps"
 msgstr "Кроки туру"
 
@@ -15582,17 +13665,13 @@ msgid "In progress"
 msgstr "В процесі"
 
 msgid "Last step index"
-msgstr ""
+msgstr "Індекс останнього кроку"
 
-#, fuzzy
-#| msgid "Completed"
 msgid "Completed at"
-msgstr "Завершено"
+msgstr "Завершено о"
 
-#, fuzzy
-#| msgid "In progress"
 msgid "Tour progress"
-msgstr "В процесі"
+msgstr "Прогрес туру"
 
 msgid "Manage Tours"
 msgstr "Керуйте турами"
@@ -15615,76 +13694,54 @@ msgstr "Auto Start Tour"
 msgid "Automatically launch a tour when a user visits a page"
 msgstr "Автоматично запускати тур, коли користувач відвідує сторінку"
 
-#, fuzzy
-#| msgid "Edit Request"
 msgid "Edit step"
-msgstr "Редагувати запит"
+msgstr "Редагувати крок"
 
-#, fuzzy
-#| msgid "Add Note"
 msgid "Add step"
-msgstr "Додати нотатку"
+msgstr "Додати крок"
 
-#, fuzzy
-#| msgid "Save filter"
 msgid "Save step"
-msgstr "Зберегти фільтр"
+msgstr "Зберегти крок"
 
-#, fuzzy
-#| msgid "Tour Steps"
 msgid "Steps"
-msgstr "Кроки туру"
+msgstr "Кроки"
 
-#, fuzzy
-#| msgid "Employement Type"
 msgid "Element"
-msgstr "Тип зайнятості"
+msgstr "Елемент"
 
-#, fuzzy
-#| msgid "Do you want to delete this stage?"
 msgid "Delete this step?"
-msgstr "Ви бажаєте видалити цей етап?"
+msgstr "Видалити цей крок?"
 
 msgid "No steps yet. Add the first one below."
-msgstr ""
+msgstr "Кроків ще немає. Додайте перший нижче."
 
 msgid ""
 "Create guided walkthroughs that appear for the right users on the right "
 "pages. Drafts stay hidden until published."
 msgstr ""
+"Створюйте покрокові тури, що з'являються для потрібних користувачів на "
+"потрібних сторінках. Чернетки приховані до публікації."
 
 msgid "Manage tour drafts and published walkthroughs from this list."
-msgstr ""
+msgstr "Керуйте чернетками й опублікованими турами з цього списку."
 
-#, fuzzy
-#| msgid "Create "
 msgid "Create Tour"
-msgstr "Створити "
+msgstr "Створити тур"
 
-#, fuzzy
-#| msgid "Task updated"
 msgid "Tour updated"
-msgstr "Завдання оновлено"
+msgstr "Тур оновлено"
 
-#, fuzzy
-#| msgid "User group created."
 msgid "Tour created"
-msgstr "Групу користувачів створено."
+msgstr "Тур створено"
 
-#, fuzzy
-#| msgid "Stage updated."
 msgid "Step updated"
-msgstr "Етап оновлено."
+msgstr "Крок оновлено"
 
-#, fuzzy
-#| msgid "Stage added."
 msgid "Step added"
-msgstr "Етап додано."
+msgstr "Крок додано"
 
-#, fuzzy
-#| msgid "Stage deleted"
 msgid "Step deleted"
-msgstr "Етап видалено"
+msgstr "Крок видалено"
 
 msgid "Feature is not enabled on the settings"
 msgstr "Функцію не увімкнено в налаштуваннях"
@@ -15722,27 +13779,23 @@ msgstr "Я вжив(ла) заходів вручну щодо захищени�
 msgid "I acknowledge, I wont be able to revert this "
 msgstr "Я підтверджую, що не зможу скасувати цю дію "
 
-#, fuzzy
-#| msgid "Group By"
 msgid "Group by"
 msgstr "Групувати за"
 
 msgid "Save filter"
 msgstr "Зберегти фільтр"
 
-#, fuzzy
-#| msgid "eye outline"
 msgid "time outline"
-msgstr "eye outline"
+msgstr "time outline"
 
 msgid "Restore the previous state"
 msgstr "Відновити попередній стан"
 
 msgid "library outline"
-msgstr ""
+msgstr "library outline"
 
 msgid "arrow back circle outline"
-msgstr ""
+msgstr "arrow back circle outline"
 
 msgid "arrow forward circle outline"
 msgstr "arrow forward circle outline"
@@ -15778,7 +13831,7 @@ msgid "Medium Priority"
 msgstr "Середній пріоритет"
 
 msgid "Alice Smith"
-msgstr ""
+msgstr "Аліса Сміт"
 
 msgid "+ Add new task"
 msgstr "+ Додати нове завдання"
@@ -15799,19 +13852,16 @@ msgstr "Недійсний формат параметра моделі."
 msgid "Deleted %(instance)s"
 msgstr "Видалено %(instance)s"
 
-#, fuzzy, python-format
-#| msgid "You don't have permission to delete."
+#, python-format
 msgid "You don't have permission to delete %(instance)s"
-msgstr "У вас немає дозволу на видалення."
+msgstr "У вас немає дозволу видаляти %(instance)s"
 
 #, python-format
 msgid "Cannot delete : %(instance)s"
 msgstr "Неможливо видалити: %(instance)s"
 
-#, fuzzy
-#| msgid "Filter Saved"
 msgid "Filter and Choose"
-msgstr "Фільтр збережено"
+msgstr "Відфільтруйте й виберіть"
 
 msgid "Unselect All"
 msgstr "Скасувати весь вибір"
@@ -15825,20 +13875,18 @@ msgstr "Фільтр"
 msgid "Page 1 of 1"
 msgstr "Сторінка 1 з 1"
 
-#, fuzzy
-#| msgid "On Leave"
 msgid "Taken Leaves"
-msgstr "У відпустці"
+msgstr "Використані відпустки"
 
-#, fuzzy
-#| msgid "Available Days"
 msgid "Add Available Days"
-msgstr "Доступні дні"
+msgstr "Додати доступні дні"
 
 msgid ""
 "Adds this value to each selected record's existing Available Days, instead "
 "of replacing it."
 msgstr ""
+"Додає це значення до наявних доступних днів кожного вибраного запису, "
+"замість заміни."
 
 msgid "Leave Reset Date"
 msgstr "Дата скидання відпустки"
@@ -15849,15 +13897,11 @@ msgstr "Призначити відпустки"
 msgid "Update Available Leave"
 msgstr "Оновити доступну відпустку"
 
-#, fuzzy
-#| msgid "Available leaves updated successfully..."
 msgid "Available Leave Updated Successfully"
-msgstr "Доступні відпустки успішно оновлено..."
+msgstr "Доступну відпустку успішно оновлено"
 
-#, fuzzy
-#| msgid "Available leaves updated successfully..."
 msgid "Available Leave Created Successfully"
-msgstr "Доступні відпустки успішно оновлено..."
+msgstr "Доступну відпустку успішно створено"
 
 msgid "Attendance Dates"
 msgstr "Дати відвідуваності"
@@ -15874,28 +13918,20 @@ msgstr "Створити запит на компенсаційну відпус
 msgid "Update Compensatory Leave Request"
 msgstr "Оновити запит на компенсаційну відпустку"
 
-#, fuzzy
-#| msgid "Compensatory Leave updated."
 msgid "Compensatory Leave Updated"
 msgstr "Компенсаційну відпустку оновлено."
 
-#, fuzzy
-#| msgid "Compensatory Leave created."
 msgid "Compensatory Leave Created"
 msgstr "Компенсаційну відпустку створено."
 
-#, fuzzy
-#| msgid "My leave allocation request"
 msgid "My Leave allocation request"
 msgstr "Мій запит на нарахування відпустки"
 
 msgid "Leave allocation requests"
 msgstr "Запити на нарахування відпустки"
 
-#, fuzzy
-#| msgid "Allocated Date"
 msgid "Bulk Allocate Leave"
-msgstr "Дата розподілу"
+msgstr "Масове нарахування відпустки"
 
 msgid "Leave Allocation Requests"
 msgstr "Запити на нарахування відпустки"
@@ -15903,24 +13939,18 @@ msgstr "Запити на нарахування відпустки"
 msgid "Attachment"
 msgstr "Вкладення"
 
-#, fuzzy
-#| msgid "Leave Allocation Request"
 msgid "Create Leave Allocation Request"
-msgstr "Запит на нарахування відпустки"
+msgstr "Створити заявку на нарахування відпустки"
 
-#, fuzzy
-#| msgid "Leave allocation requests"
 msgid "Leave allocation request updated"
-msgstr "Запити на нарахування відпустки"
+msgstr "Заявку на нарахування відпустки оновлено"
 
-#, fuzzy
-#| msgid "New Leave allocation request is created"
 msgid "New leave allocation request created"
-msgstr "Створено новий запит на розподіл відпустки"
+msgstr "Нову заявку на нарахування відпустки створено"
 
 #, python-format
 msgid "Leave allocated for %(count)s employee(s)"
-msgstr ""
+msgstr "Відпустку нараховано для %(count)s співробітник(ів)"
 
 msgid "Leave Clash"
 msgstr "Конфлікт відпусток"
@@ -15928,45 +13958,29 @@ msgstr "Конфлікт відпусток"
 msgid "Leave Requests"
 msgstr "Запити на відпустку"
 
-#, fuzzy
-#| msgid "Leave request is updated successfully.."
 msgid "Leave request is updated successfully"
 msgstr "Заявку на відпустку успішно оновлено.."
 
-#, fuzzy
-#| msgid "Leave request created successfully.."
 msgid "Leave request created successfully"
 msgstr "Заявку на відпустку успішно створено.."
 
-#, fuzzy
-#| msgid "Clashed Due To"
 msgid "Clased Due To"
-msgstr "Причина конфлікту"
+msgstr "Закрито через"
 
-#, fuzzy
-#| msgid "Deducted From "
 msgid "Deducted FromCFD"
-msgstr "Утримано з "
+msgstr "Утримано з перенесених"
 
-#, fuzzy
-#| msgid "Approve"
 msgid "Approval"
-msgstr "Затвердити"
+msgstr "Погодження"
 
-#, fuzzy
-#| msgid "Is Encashable"
 msgid "Encashable"
 msgstr "Підлягає компенсації"
 
-#, fuzzy
-#| msgid "Condition"
 msgid "Conditions"
-msgstr "Умова"
+msgstr "Умови"
 
-#, fuzzy
-#| msgid "Paid"
 msgid "Un Paid"
-msgstr "Оплачено"
+msgstr "Неоплачувана"
 
 msgid "Leave Types"
 msgstr "Типи відпусток"
@@ -15989,51 +14003,34 @@ msgstr "Скидання вихідних"
 msgid "Maximum Carryforward"
 msgstr "Максимальне перенесення"
 
-#, fuzzy
-#| msgid "Carryforward Expire In"
 msgid "Carryforward Expires In"
-msgstr "Термін дії перенесення (через)"
+msgstr "Перенесене спливає через"
 
-#, fuzzy, python-brace-format
-#| msgid "employee-report"
+#, python-brace-format
 msgid "{employee}: {reason}"
-msgstr "звіт по співробітниках"
+msgstr "{employee}: {reason}"
 
-#, fuzzy
-#| msgid "Leave types assigned successfully."
 msgid "Leave type assign is successfull"
-msgstr "Типи відпусток успішно призначено."
+msgstr "Тип відпустки успішно призначено"
 
-#, fuzzy
-#| msgid "Leave type has already been assigned to the employee."
 msgid "leave type is already assigned to the employee"
-msgstr "Цей тип відпустки вже призначено співробітнику."
+msgstr "тип відпустки вже призначено співробітнику"
 
-#, fuzzy
-#| msgid "Compensatory leave type cannot be assigned manually."
 msgid "Compensatory leave type cant assigned manually"
-msgstr "Компенсаційну відпустку не можна призначити вручну."
+msgstr "Компенсаційну відпустку не можна призначити вручну"
 
-#, fuzzy
-#| msgid "My Leave Requests"
 msgid "My Leave requests"
 msgstr "Мої заявки на відпустку"
 
 msgid "Leave Request Update"
 msgstr "Оновлення заявки на відпустку"
 
-#, fuzzy
-#| msgid "Leave request updated successfully.."
 msgid "Leave request updated successfully"
 msgstr "Заявку на відпустку успішно оновлено.."
 
-#, fuzzy
-#| msgid "You dont have enough leave days to make the request.."
 msgid "You dont have enough leave days to make the request"
 msgstr "У вас недостатньо днів відпустки для подання цього запиту.."
 
-#, fuzzy
-#| msgid "There is already a leave request for this date range."
 msgid "There is already a leave request for this date range"
 msgstr "Для цього діапазону дат уже є запит на відпустку."
 
@@ -16043,23 +14040,17 @@ msgstr "Створити обмежений день"
 msgid "Update Restricted Day"
 msgstr "Оновити обмежений день"
 
-#, fuzzy
-#| msgid "Restricted day updated successfully.."
 msgid "Restricted Day Updated Successfully"
 msgstr "Обмежений день успішно оновлено.."
 
-#, fuzzy
-#| msgid "Restricted day created successfully.."
 msgid "Restricted Day Created Successfully"
 msgstr "Обмежений день успішно створено.."
 
 msgid "Leave allocation request not found"
 msgstr "Заявку на нарахування відпустки не знайдено"
 
-#, fuzzy
-#| msgid "Compensatory leave is not enabled."
 msgid "Sorry,Compensatory leave is not enabled."
-msgstr "Компенсаційну відпустку не увімкнено."
+msgstr "На жаль, компенсаційна відпустка не увімкнена."
 
 msgid "Total Leave Days Days"
 msgstr "Загальна кількість днів відпустки"
@@ -16068,12 +14059,10 @@ msgid "A value is required for the selected condition type."
 msgstr "Для вибраного типу умови потрібне значення."
 
 msgid "Payment percentage is required for Custom payment type."
-msgstr ""
+msgstr "Для власного типу оплати потрібен відсоток оплати."
 
-#, fuzzy
-#| msgid "Day percentage must be between 0.0 and 1.0"
 msgid "Payment percentage must be between 0 and 100."
-msgstr "Відсоток дня має бути в діапазоні від 0.0 до 1.0"
+msgstr "Відсоток оплати мусить бути від 0 до 100."
 
 msgid "Rejection Reason"
 msgstr "Причина відхилення"
@@ -16117,6 +14106,8 @@ msgstr "Залишити Тип Умови"
 msgid ""
 "Specifies how leave days are paid: fully, half, unpaid, or custom percentage"
 msgstr ""
+"Визначає, як оплачуються дні відпустки: повністю, наполовину, без оплати чи "
+"власний відсоток"
 
 msgid "Payment Percentage"
 msgstr "Відсоток оплати"
@@ -16125,11 +14116,15 @@ msgid ""
 "Percentage of salary paid during leave (0–100). Used only when Payment Type "
 "is Custom."
 msgstr ""
+"Відсоток зарплати, що виплачується під час відпустки (0–100). Лише для "
+"власного типу оплати."
 
 msgid ""
 "Eligibility conditions evaluated before assigning this leave type to an "
 "employee"
 msgstr ""
+"Умови участі, що перевіряються перед призначенням цього типу відпустки "
+"співробітнику"
 
 msgid "Compensatory Leave Request already exists."
 msgstr "Заявка на компенсаційну відпустку вже існує."
@@ -16163,6 +14158,9 @@ msgid ""
 "dates, breakdown and the leave type's holiday/company leave exclusion "
 "settings."
 msgstr ""
+"Кількість запитаних днів для цього типу відпустки — нуль. Перевірте вибрані "
+"дати, розбивку та налаштування виключення свят/вихідних компанії для цього "
+"типу."
 
 msgid "Does not have sufficient leave balance for the requested dates."
 msgstr "Недостатньо залишку відпустки для запитаних дат."
@@ -16181,7 +14179,7 @@ msgid "Leave Allocation Request"
 msgstr "Запит на нарахування відпустки"
 
 msgid "This form cannot be edited because the status is Requested / Rejected."
-msgstr ""
+msgstr "Цю форму не можна редагувати, бо статус — «Запитано» / «Відхилено»."
 
 msgid ""
 "If no job positions are specifically selected, the system will consider all "
@@ -16208,41 +14206,45 @@ msgstr "Виключити типи відпусток"
 msgid "Choose leave types to exclude from restriction."
 msgstr "Оберіть типи відпусток, які слід виключити з обмеження."
 
-#, fuzzy, python-brace-format
-#| msgid "Some leave types were already assigned to {} employees."
+#, python-brace-format
 msgid "This leave type is restricted to {gender} employees only."
-msgstr "Деякі типи відпусток вже було призначено {} співробітникам."
+msgstr "Цей тип відпустки доступний лише співробітникам: {gender}."
 
-#, fuzzy, python-brace-format
-#| msgid "Leave type has already been assigned to the employee."
+#, python-brace-format
 msgid ""
 "'{leave_type}' can only be assigned once per employment and has already been"
 " assigned to this employee."
-msgstr "Цей тип відпустки вже призначено співробітнику."
+msgstr ""
+"'{leave_type}' можна призначити лише раз за період роботи, і цьому "
+"співробітнику його вже призначено."
 
 #, python-brace-format
 msgid ""
 "This leave type is restricted to employees with marital status: {status}."
-msgstr ""
+msgstr "Цей тип відпустки доступний лише співробітникам зі станом: {status}."
 
 #, python-brace-format
 msgid ""
 "This leave type is restricted to employees with nationality: {nationality}."
 msgstr ""
+"Цей тип відпустки доступний лише співробітникам із громадянством: "
+"{nationality}."
 
 #, python-brace-format
 msgid ""
 "This leave type is restricted to employees in the {department} department."
-msgstr ""
+msgstr "Цей тип відпустки доступний лише співробітникам відділу {department}."
 
 #, python-brace-format
 msgid ""
 "This leave type is restricted to employees with employment type: {emp_type}."
 msgstr ""
+"Цей тип відпустки доступний лише співробітникам із типом зайнятості: "
+"{emp_type}."
 
 #, python-brace-format
 msgid "This leave type is restricted to employees with grade: {grade}."
-msgstr ""
+msgstr "Цей тип відпустки доступний лише співробітникам з грейдом: {grade}."
 
 msgid "My Leave Requests"
 msgstr "Мої заявки на відпустку"
@@ -16320,18 +14322,18 @@ msgstr "Той самий відділ"
 msgid "Same Job Position"
 msgstr "Та сама посада"
 
-#, fuzzy
-#| msgid "'s leave request"
 msgid "Cannot submit leave request"
-msgstr " запит на відпустку"
+msgstr "Не вдалося подати заявку на відпустку"
 
 msgid ""
 "The selected dates result in 0 leave days for this leave type. Please adjust"
 " the dates, breakdown or leave type."
 msgstr ""
+"Вибрані дати дають 0 днів відпустки для цього типу. Змініть дати, розбивку "
+"або тип відпустки."
 
 msgid "OK"
-msgstr ""
+msgstr "OK"
 
 msgid "has an interview in this requested date range."
 msgstr " має співбесіду в цьому запитаному діапазоні дат."
@@ -16346,11 +14348,15 @@ msgid ""
 "Define the different types of leave employees can request, along with "
 "payment and carry-forward rules."
 msgstr ""
+"Визначте типи відпусток, які можуть запитувати співробітники, разом із "
+"правилами оплати й перенесення."
 
 msgid ""
 "Configure department-based conditions and manager sequences for multi-level "
 "request approvals."
 msgstr ""
+"Налаштуйте умови за відділами та послідовності керівників для багатоетапного"
+" погодження заявок."
 
 msgid "Carryforward Expire in"
 msgstr "Термін дії перенесення закінчується через"
@@ -16379,10 +14385,8 @@ msgstr "Загальна кількість днів більше або дор�
 msgid "Total Days less Than or Equal"
 msgstr "Загальна кількість днів менше або дорівнює"
 
-#, fuzzy
-#| msgid "Remaining"
 msgid "warning"
-msgstr "Залишок"
+msgstr "попередження"
 
 msgid "You have an interview in this requested date range."
 msgstr "У вас є співбесіда в цьому запитаному діапазоні дат."
@@ -16470,6 +14474,8 @@ msgid ""
 "The selected dates result in 0 leave days for this leave type. This request "
 "cannot be submitted."
 msgstr ""
+"Вибрані дати дають 0 днів відпустки для цього типу. Цю заявку не можна "
+"подати."
 
 #, python-format
 msgid ""
@@ -16481,8 +14487,17 @@ msgid_plural ""
 "                The selected dates include company holidays: %(names)s.\n"
 "            "
 msgstr[0] ""
+"\n"
+"                Вибрані дати містять свято компанії: %(names)s.\n"
+"            "
 msgstr[1] ""
+"\n"
+"                Вибрані дати містять свята компанії: %(names)s.\n"
+"            "
 msgstr[2] ""
+"\n"
+"                Вибрані дати містять свята компанії: %(names)s.\n"
+"            "
 
 msgid "Select All Requests"
 msgstr "Обрати всі запити"
@@ -16578,27 +14593,23 @@ msgid "Cancellation Reason"
 msgstr "Причина скасування"
 
 msgid "Eligibility Conditions"
-msgstr ""
+msgstr "Умови участі"
 
 msgid ""
 "Only employees matching all conditions below will be eligible for this leave"
 " type."
 msgstr ""
+"Лише співробітники, що відповідають усім умовам нижче, зможуть отримати цей "
+"тип відпустки."
 
-#, fuzzy
-#| msgid "Return Condition"
 msgid "Remove this condition?"
-msgstr "Стан при поверненні"
+msgstr "Видалити цю умову?"
 
-#, fuzzy
-#| msgid "The selected leave type is not assigned to this employee."
 msgid "No conditions set — this leave type can be assigned to any employee."
-msgstr "Обраний тип відпустки не призначено цьому співробітнику."
+msgstr "Умов не задано — цей тип відпустки можна призначити будь-кому."
 
-#, fuzzy
-#| msgid "Condition"
 msgid "Add Condition"
-msgstr "Умова"
+msgstr "Додати умову"
 
 msgid "Do you need to attach a document for leave?"
 msgstr "Потрібно додавати документ для відпустки?"
@@ -16613,10 +14624,10 @@ msgid "Do you need to exclude public holidays from the requested leave days?"
 msgstr "Потрібно виключати державні свята з запитаних днів відпустки?"
 
 msgid "Eligibility conditions"
-msgstr ""
+msgstr "Умови участі"
 
 msgid "Eligibility conditions can be configured after saving the leave type."
-msgstr ""
+msgstr "Умови участі можна налаштувати після збереження типу відпустки."
 
 msgid "No leave types have been created yet."
 msgstr "Ще не створено жодного типу відпустки."
@@ -16657,10 +14668,8 @@ msgstr "Немає доступних обмежених дат."
 msgid "Restricted Days"
 msgstr "Обмежені дні"
 
-#, fuzzy
-#| msgid "IP Restriction"
 msgid "Past Leave Restriction"
-msgstr "Обмеження за IP"
+msgstr "Обмеження минулих відпусток"
 
 msgid "Restricts Past Date Leave Request Creation"
 msgstr "Обмежує створення заявок на відпустку за минулі дати"
@@ -16676,6 +14685,8 @@ msgid ""
 "Define date ranges during which leave requests are restricted for selected "
 "departments or job positions."
 msgstr ""
+"Визначте діапазони дат, у які заявки на відпустку обмежені для вибраних "
+"відділів або посад."
 
 msgid "New leave type Created.."
 msgstr "Новий тип відпустки створено.."
@@ -16707,23 +14718,19 @@ msgstr "Заявку на відпустку успішно видалено.."
 msgid "Leave request not found."
 msgstr "Заявку на відпустку не знайдено."
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No leave rquest found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Заявок на відпустку за цим запитом не знайдено."
 
-#, fuzzy
-#| msgid "You can't cancel this leave request."
 msgid "You cannot approve your own leave request."
-msgstr "Ви не можете скасувати цю заявку на відпустку."
+msgstr "Ви не можете затвердити власну заявку на відпустку."
 
 msgid "No available leave record found for this employee and leave type."
 msgstr ""
+"Для цього співробітника й типу відпустки записів про доступні дні не "
+"знайдено."
 
-#, fuzzy
-#| msgid "You can't cancel this leave request."
 msgid "You are not an approver for this leave request."
-msgstr "Ви не можете скасувати цю заявку на відпустку."
+msgstr "Ви не є погоджувачем цієї заявки на відпустку."
 
 msgid "Leave request approved successfully.."
 msgstr "Заявку на відпустку успішно погоджено.."
@@ -16769,7 +14776,7 @@ msgstr "Тип відпустки вже призначено деяким ви�
 
 #, python-brace-format
 msgid "{employee} — {leave_type}: {reason}"
-msgstr ""
+msgstr "{employee} — {leave_type}: {reason}"
 
 msgid "Leave types assigned successfully."
 msgstr "Типи відпусток успішно призначено."
@@ -16854,10 +14861,8 @@ msgstr "Цього місяця немає заявок на жоден тип �
 msgid "Leave Trends"
 msgstr "Тенденції відпусток"
 
-#, fuzzy
-#| msgid "No Attachment found matching the query."
 msgid "No leave found matching the query."
-msgstr "Вкладень, що відповідають запиту, не знайдено."
+msgstr "Відпусток за цим запитом не знайдено."
 
 msgid "New Leave allocation request is created"
 msgstr "Створено новий запит на розподіл відпустки"
@@ -16908,10 +14913,8 @@ msgstr "Заявку на відпустку видалено."
 msgid "You cannot delete leave request with status {}."
 msgstr "Не можна видалити заявку на відпустку зі статусом {}."
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No comment found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Коментарів за цим запитом не знайдено."
 
 msgid "Compensatory leave is enabled successfully!"
 msgstr "Компенсаційну відпустку успішно увімкнено!"
@@ -16919,15 +14922,11 @@ msgstr "Компенсаційну відпустку успішно увімк�
 msgid "Compensatory leave is disabled successfully!"
 msgstr "Компенсаційну відпустку успішно вимкнено!"
 
-#, fuzzy
-#| msgid "No Attachment found matching the query."
 msgid "No attendance found matching the query."
-msgstr "Вкладень, що відповідають запиту, не знайдено."
+msgstr "Записів відвідуваності за цим запитом не знайдено."
 
-#, fuzzy
-#| msgid "No Attachment found matching the query."
 msgid "No leave comment found matching the query."
-msgstr "Вкладень, що відповідають запиту, не знайдено."
+msgstr "Коментарів до відпустки за цим запитом не знайдено."
 
 msgid "Compensatory Leave updated."
 msgstr "Компенсаційну відпустку оновлено."
@@ -16947,85 +14946,53 @@ msgstr "Заявка на компенсаційну відпустку не м�
 msgid "Compensatory Leave request rejected."
 msgstr "Заявку на компенсаційну відпустку відхилено."
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No interview found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Співбесід за цим запитом не знайдено."
 
-#, fuzzy
-#| msgid "No Leave requests have been generated."
 msgid "Past Date Leave Request Restriction has been enabled"
-msgstr "Запитів на відпустку не створено."
+msgstr "Обмеження заявок на відпустку минулими датами увімкнено"
 
-#, fuzzy
-#| msgid "Restricts Past Date Leave Request Creation"
 msgid "Past Date Leave Request Restriction has been disabled"
-msgstr "Обмежує створення заявок на відпустку за минулі дати"
+msgstr "Обмеження заявок на відпустку минулими датами вимкнено"
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No leave request found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Заявок на відпустку за цим запитом не знайдено."
 
-#, fuzzy
-#| msgid "Candidate added successfully."
 msgid "Condition added successfully."
-msgstr "Кандидата успішно додано."
+msgstr "Умову успішно додано."
 
-#, fuzzy
-#| msgid "Interviewer removed succesfully."
 msgid "Condition removed successfully."
-msgstr "Інтерв'юера успішно видалено."
+msgstr "Умову успішно вилучено."
 
-#, fuzzy
-#| msgid "Candidate Onboarding Stage"
 msgid "Create Offboarding Stage"
-msgstr "Етап адаптації кандидата"
+msgstr "Створити етап звільнення"
 
-#, fuzzy
-#| msgid "Candidate Onboarding Stage"
 msgid "Update Offboarding Stage"
-msgstr "Етап адаптації кандидата"
+msgstr "Оновити етап звільнення"
 
-#, fuzzy
-#| msgid "Candidate Updated Successfully."
 msgid "Offboarding Stage Updated Successfully"
-msgstr "Дані кандидата успішно оновлено."
+msgstr "Етап звільнення успішно оновлено"
 
-#, fuzzy
-#| msgid "Bank Details Created Successfully"
 msgid "Offboarding Stage Created Successfully"
-msgstr "Банківські реквізити успішно створено"
+msgstr "Етап звільнення успішно створено"
 
-#, fuzzy
-#| msgid "Update Employee Tag"
 msgid "Update Employee"
-msgstr "Оновити тег працівника"
+msgstr "Оновити співробітника"
 
-#, fuzzy
-#| msgid "Update Employee Tag"
 msgid "Updated Employee"
-msgstr "Оновити тег працівника"
+msgstr "Співробітника оновлено"
 
-#, fuzzy
-#| msgid "Add Employee"
 msgid "Added Employee"
-msgstr "Додати співробітника"
+msgstr "Співробітника додано"
 
-#, fuzzy
-#| msgid "Offboarding"
 msgid "Create Offboarding"
-msgstr "Звільнення"
+msgstr "Створити звільнення"
 
-#, fuzzy
-#| msgid "Offboarding"
 msgid "Update Offboarding"
-msgstr "Звільнення"
+msgstr "Оновити звільнення"
 
-#, fuzzy
-#| msgid "Offboarding deleted"
 msgid "Offboarding Updated"
-msgstr "Звільнення видалено"
+msgstr "Звільнення оновлено"
 
 msgid "Offboarding saved"
 msgstr "Звільнення збережено"
@@ -17036,8 +15003,6 @@ msgstr "Створити завдання"
 msgid "Update Task"
 msgstr "Оновити завдання"
 
-#, fuzzy
-#| msgid "Task updated"
 msgid "Task Updated"
 msgstr "Завдання оновлено"
 
@@ -17063,13 +15028,15 @@ msgid "Add Stage"
 msgstr "Додати етап"
 
 msgid "Manage Stage Order"
-msgstr ""
+msgstr "Керувати порядком етапів"
 
 #, python-format
 msgid ""
 "Complete the following required task(s) before moving to the next stage: "
 "%(tasks)s"
 msgstr ""
+"Виконайте наступні обов'язкові завдання перед переходом на наступний етап: "
+"%(tasks)s"
 
 msgid "Notice Period"
 msgstr "Термін попередження"
@@ -17077,33 +15044,23 @@ msgstr "Термін попередження"
 msgid "Resignations"
 msgstr "Звільнення"
 
-#, fuzzy
-#| msgid "Planned to leave on"
 msgid "Planned to leave date"
 msgstr "Планова дата звільнення"
 
-#, fuzzy
-#| msgid "Resignation Letters"
 msgid "Create Resignation Letter"
-msgstr "Заяви на звільнення"
+msgstr "Створити заяву на звільнення"
 
-#, fuzzy
-#| msgid "Question updated successfully."
 msgid "Resignation updated successfully"
-msgstr "Запитання успішно оновлено."
+msgstr "Звільнення успішно оновлено"
 
-#, fuzzy
-#| msgid "Question created successfully."
 msgid "Resignation created successfully"
-msgstr "Запитання успішно створено."
+msgstr "Звільнення успішно створено"
 
 msgid "Resignation"
 msgstr "Звільнення за власним бажанням"
 
-#, fuzzy
-#| msgid "Task"
 msgid "Task To"
-msgstr "Завдання"
+msgstr "Завдання для"
 
 msgid "You cannot edit a request that has been rejected/approved"
 msgstr "Ви не можете редагувати запит, який було відхилено/схвалено"
@@ -17135,28 +15092,24 @@ msgstr "сьогодні"
 msgid "Notice period ended"
 msgstr "Термін попередження закінчився"
 
-#, fuzzy
-#| msgid "task"
 msgid "tasks"
 msgstr "завдання"
 
-#, fuzzy
-#| msgid "Planned To Leave"
 msgid "Planned To Leave On"
 msgstr "Планова дата звільнення"
 
 msgid "A rejected resignation letter cannot be modified."
-msgstr ""
+msgstr "Відхилену заяву на звільнення не можна змінити."
 
 msgid ""
 "A resignation letter for this employee is already in 'Requested' or "
 "'Approved' status."
 msgstr ""
+"Заява на звільнення цього співробітника вже має статус «Запитано» або "
+"«Затверджено»."
 
-#, fuzzy
-#| msgid "Is Hired"
 msgid "Is Required"
-msgstr "Найнято"
+msgstr "Обов'язкове"
 
 msgid "Todo"
 msgstr "До виконання"
@@ -17182,24 +15135,20 @@ msgstr "Дозвольте співробітникам подавати зая�
 msgid "Default days between resignation and last working day"
 msgstr "Дні за замовчуванням між звільненням і останнім робочим днем"
 
-#, fuzzy
-#| msgid "No Records found."
 msgid "No Records found..."
 msgstr "Записів не знайдено."
 
 msgid "Show managing records"
 msgstr "Показати керовані записи"
 
-#, fuzzy
-#| msgid "Do you want to delete this asset?"
 msgid "Do you want to delete this offboarding user?"
-msgstr "Ви бажаєте видалити цей актив?"
+msgstr "Ви бажаєте видалити цього співробітника зі звільнення?"
 
 msgid "mail open outline"
 msgstr "mail open outline"
 
 msgid "checkmark"
-msgstr ""
+msgstr "checkmark"
 
 msgid "Planned to resign"
 msgstr "Планує звільнитися"
@@ -17207,13 +15156,9 @@ msgstr "Планує звільнитися"
 msgid "Job position"
 msgstr "Посада"
 
-#, fuzzy
-#| msgid "Start Date"
 msgid "Start Date:"
 msgstr "Дата початку"
 
-#, fuzzy
-#| msgid "End Date"
 msgid "End Date:"
 msgstr "Дата закінчення"
 
@@ -17229,156 +15174,98 @@ msgstr "Планова дата звільнення"
 msgid "Notice period end"
 msgstr "Закінчення строку попередження"
 
-#, fuzzy
-#| msgid "Offboarding saved"
 msgid "Offboarding Dashboard"
-msgstr "Звільнення збережено"
+msgstr "Дашборд звільнень"
 
-#, fuzzy
-#| msgid "offboarding-pipeline"
 msgid "Offboarding Pipeline"
 msgstr "процес звільнення"
 
-#, fuzzy
-#| msgid "Employee tag"
 msgid "Employees by stage"
-msgstr "Тег співробітника"
+msgstr "Співробітники за етапами"
 
-#, fuzzy
-#| msgid "Resignation Letters"
 msgid "Resignation Status"
-msgstr "Заяви на звільнення"
+msgstr "Статус заяви на звільнення"
 
-#, fuzzy
-#| msgid "Permissions"
 msgid "Letter submissions"
-msgstr "Дозволи"
+msgstr "Подані заяви"
 
-#, fuzzy
-#| msgid "Completing"
 msgid "Task Completion"
-msgstr "Завершення"
+msgstr "Завершення завдань"
 
-#, fuzzy
-#| msgid "Onboarding Tasks"
 msgid "All offboarding tasks"
-msgstr "Завдання адаптації"
+msgstr "Усі завдання звільнення"
 
-#, fuzzy
-#| msgid "Department Chart"
 msgid "Department Attrition"
-msgstr "Діаграма відділів"
+msgstr "Плинність за відділами"
 
-#, fuzzy
-#| msgid "Offboarding deleted"
 msgid "Offboarding by department"
-msgstr "Звільнення видалено"
+msgstr "Звільнення за відділами"
 
-#, fuzzy
-#| msgid "Exit Ratio"
 msgid "Exit Reasons"
-msgstr "Коефіцієнт звільнень"
+msgstr "Причини звільнення"
 
-#, fuzzy
-#| msgid "Employee Leaves"
 msgid "Why employees leave"
-msgstr "Відпустки співробітників"
+msgstr "Чому співробітники йдуть"
 
-#, fuzzy
-#| msgid "Joining Set"
 msgid "Joining vs Exiting"
-msgstr "Дату прийому встановлено"
+msgstr "Прийоми та звільнення"
 
-#, fuzzy
-#| msgid "Notice Period Starts"
 msgid "Notice Period Tracker"
-msgstr "Початок терміну попередження"
+msgstr "Відстеження терміну відпрацювання"
 
-#, fuzzy
-#| msgid "Not Returned Assets"
 msgid "Unreturned Assets"
-msgstr "Не повернені активи"
+msgstr "Неповернені активи"
 
-#, fuzzy
-#| msgid "Offboarding"
 msgid "Active Offboarding"
-msgstr "Звільнення"
+msgstr "Активні звільнення"
 
-#, fuzzy
-#| msgid "Exit Ratio"
 msgid "exit rate"
-msgstr "Коефіцієнт звільнень"
+msgstr "коефіцієнт звільнень"
 
-#, fuzzy
-#| msgid "Pending Hour"
 msgid "Pending review"
-msgstr "Очікувана година"
+msgstr "Очікує перегляду"
 
 msgid "tasks done"
-msgstr ""
+msgstr "завдань виконано"
 
-#, fuzzy
-#| msgid "Contracts ending "
 msgid "notice ending"
-msgstr "Завершення контрактів "
+msgstr "завершення відпрацювання"
 
-#, fuzzy
-#| msgid "offboarding"
 msgid "Completed offboarding"
-msgstr "звільнення"
+msgstr "Завершені звільнення"
 
-#, fuzzy
-#| msgid "Offboarding saved"
 msgid "No offboarding stages"
-msgstr "Звільнення збережено"
+msgstr "Немає етапів звільнення"
 
-#, fuzzy
-#| msgid "Resignations"
 msgid "No resignations"
+msgstr "Немає заяв на звільнення"
+
+msgid "No tasks"
+msgstr "Немає завдань"
+
+msgid "No exit reasons recorded"
+msgstr "Причин звільнення не зафіксовано"
+
+msgid "Count"
+msgstr "Кількість"
+
+msgid "Joining"
+msgstr "Прийом на роботу"
+
+msgid "Exiting"
 msgstr "Звільнення"
 
-#, fuzzy
-#| msgid "No of Tasks"
-msgid "No tasks"
-msgstr "Кількість завдань"
-
-#, fuzzy
-#| msgid "No tax filing status has been recorded."
-msgid "No exit reasons recorded"
-msgstr "Не зареєстровано жодного статусу подання податкової звітності."
-
-#, fuzzy
-#| msgid "Country"
-msgid "Count"
-msgstr "Країна"
-
-#, fuzzy
-#| msgid "Joining Set"
-msgid "Joining"
-msgstr "Дату прийому встановлено"
-
-#, fuzzy
-#| msgid "Rating"
-msgid "Exiting"
-msgstr "Оцінка"
-
-#, fuzzy
-#| msgid "Notice period"
 msgid "No active notice periods"
-msgstr "Термін попередження"
+msgstr "Немає активних термінів відпрацювання"
 
 msgid "Ended"
-msgstr ""
+msgstr "Завершено"
 
-#, fuzzy
-#| msgid "Already Returned"
 msgid "All assets returned"
-msgstr "Вже повернувся"
+msgstr "Усі активи повернено"
 
-#, fuzzy
-#| msgid "Not Returned Assets"
 msgid "Not returned"
-msgstr "Не повернені активи"
+msgstr "Не повернено"
 
 msgid "Reminder"
 msgstr "Нагадування"
@@ -17393,26 +15280,24 @@ msgstr "Немає відгуків від співробітників, що з
 msgid "No Pending Tasks for Offboarding Employees."
 msgstr "Немає незавершених завдань для співробітників, що звільняються."
 
-#, fuzzy
-#| msgid "Are you sure you want to delete this record?"
 msgid "Are you sure you want to delete this offboarding?"
-msgstr "Ви впевнені, що хочете видалити цей запис?"
+msgstr "Ви впевнені, що хочете видалити це звільнення?"
 
 msgid "There is no offboardings at this moment."
 msgstr "Наразі немає звільнень."
 
 msgid "list outline"
-msgstr ""
+msgstr "list outline"
 
 msgid "grid outline"
-msgstr ""
+msgstr "grid outline"
 
 msgid " Send Mail"
 msgstr " Надіслати лист"
 
 #, python-format
 msgid "{%%trans \\"
-msgstr ""
+msgstr "{%%trans \\"
 
 msgid "No search results found!"
 msgstr "Результатів пошуку не знайдено!"
@@ -17424,36 +15309,29 @@ msgid "No resignation has been created yet."
 msgstr "Заяв на звільнення ще не створено."
 
 msgid "Configure how employees exit the organization."
-msgstr ""
+msgstr "Налаштуйте, як співробітники покидають організацію."
 
-#, fuzzy
-#| msgid ""
-#| "By enabling this normal users can request for their resignation progress"
 msgid ""
 "By enabling this normal users can request for their resignation progress."
 msgstr ""
 "Увімкнувши це, звичайні користувачі зможуть подавати заяву щодо ходу свого "
 "звільнення"
 
-#, fuzzy
-#| msgid " Set initial notice period (in days)"
 msgid "Set initial notice period (in days)"
 msgstr " Встановити початковий термін попередження (у днях)"
 
-#, fuzzy
-#| msgid "Default days between resignation and last working day"
 msgid ""
 "Set the default number of days an employee must serve between resignation "
 "and their last working day."
-msgstr "Дні за замовчуванням між звільненням і останнім робочим днем"
+msgstr ""
+"Задайте типову кількість днів між заявою на звільнення та останнім робочим "
+"днем."
 
 msgid "Are you sure want to delete this stage?"
 msgstr "Ви впевнені, що хочете видалити цей етап?"
 
-#, fuzzy
-#| msgid "Do you want to delete this task?"
 msgid "Do you want to delete task?"
-msgstr "Бажаєте видалити це завдання?"
+msgstr "Ви бажаєте видалити завдання?"
 
 msgid "Offboarding deleted"
 msgstr "Звільнення видалено"
@@ -17490,19 +15368,17 @@ msgid ""
 "Complete the following required task(s) before moving to the next stage: "
 "%(details)s"
 msgstr ""
+"Виконайте наступні обов'язкові завдання перед переходом на наступний етап: "
+"%(details)s"
 
-#, fuzzy
-#| msgid "Create a new Stage"
 msgid "Cannot Change Stage"
-msgstr "Створити етап проєкту"
+msgstr "Не можна змінити етап"
 
 msgid "stage changed successfully."
 msgstr "Етап успішно змінено."
 
-#, fuzzy
-#| msgid "Missing required parameters."
 msgid "Missing required parameter."
-msgstr "Відсутні необхідні параметри."
+msgstr "Відсутній обов'язковий параметр."
 
 msgid "Note added successfully"
 msgstr "Примітку успішно додано"
@@ -17516,10 +15392,8 @@ msgstr "Примітку не знайдено."
 msgid "Missing required parameters."
 msgstr "Відсутні необхідні параметри."
 
-#, fuzzy
-#| msgid "Task updated successfully.."
 msgid "Task status updated successfully..."
-msgstr "Завдання успішно оновлено.."
+msgstr "Статус завдання успішно оновлено..."
 
 msgid "Task status changed successfully."
 msgstr "Статус завдання успішно змінено."
@@ -17533,10 +15407,8 @@ msgstr "Завдання призначено"
 msgid "Task deleted"
 msgstr "Завдання видалено"
 
-#, fuzzy
-#| msgid "Resignation letter deleted"
 msgid "Resignation letter not found"
-msgstr "Заяву на звільнення видалено"
+msgstr "Заяву на звільнення не знайдено"
 
 msgid "Resignation letter deleted"
 msgstr "Заяву на звільнення видалено"
@@ -17544,6 +15416,7 @@ msgstr "Заяву на звільнення видалено"
 msgid ""
 "A rejected resignation letter cannot be modified. Only deletion is allowed."
 msgstr ""
+"Відхилену заяву на звільнення не можна змінити. Дозволено лише видалення."
 
 msgid "Resignation letter saved"
 msgstr "Заяву на звільнення збережено"
@@ -17551,7 +15424,7 @@ msgstr "Заяву на звільнення збережено"
 #, python-format
 msgid ""
 "%(name)s's resignation letter is already rejected and cannot be modified."
-msgstr ""
+msgstr "Заява на звільнення %(name)s вже відхилена й не може бути змінена."
 
 #, python-format
 msgid "Resignation request has been %(status)s"
@@ -17563,8 +15436,6 @@ msgstr "Налаштування заяв на звільнення успішн
 msgid "Scheduled"
 msgstr "Заплановано"
 
-#, fuzzy
-#| msgid "Candidate"
 msgid "Candidaate"
 msgstr "Кандидат"
 
@@ -17586,104 +15457,68 @@ msgstr "Дата виходу не встановлена"
 msgid "Portal Not-Sent"
 msgstr "Портал не надіслано"
 
-#, fuzzy
-#| msgid "Portal Sent"
 msgid "Portal Send"
 msgstr "Портал надіслано"
 
-#, fuzzy
-#| msgid "Probation ends"
 msgid "Probation End"
-msgstr "Закінчення випробувального терміну"
+msgstr "Кінець випробувального"
 
-#, fuzzy
-#| msgid "Reject Reason"
 msgid "Rejected Reason"
 msgstr "Причина відхилення"
 
 msgid "Send Portal"
 msgstr "Надіслати портал"
 
-#, fuzzy
-#| msgid "Create Tag"
 msgid "Create Stage"
-msgstr "Створити тег"
+msgstr "Створити етап"
 
-#, fuzzy
-#| msgid "Update Image"
 msgid "Update Stage"
-msgstr "Оновити зображення"
+msgstr "Оновити етап"
 
-#, fuzzy
-#| msgid "Stage deleted successfully"
 msgid "Stage Updated Successfully"
-msgstr "Етап успішно видалено"
+msgstr "Етап успішно оновлено"
 
-#, fuzzy
-#| msgid "New stage created successfully.."
 msgid "New stage created successfully"
 msgstr "Новий етап успішно створено.."
 
-#, fuzzy
-#| msgid "New task created successfully..."
 msgid "New Task Created Successfully"
 msgstr "Нове завдання успішно створено..."
 
 msgid "Task updated successfully.."
 msgstr "Завдання успішно оновлено.."
 
-#, fuzzy
-#| msgid "Onboarding portal stage"
 msgid "Onboarding Portal Stage"
 msgstr "Етап порталу адаптації"
 
-#, fuzzy
-#| msgid "pipeline"
 msgid "Pipeline"
 msgstr "воронка підбору"
 
 msgid "Rating"
 msgstr "Оцінка"
 
-#, fuzzy
-#| msgid " View Note"
 msgid "View Note"
 msgstr " Переглянути нотатку"
 
-#, fuzzy
-#| msgid "You have been logged out."
 msgid "You are not logged in."
-msgstr "Ви вийшли з системи."
+msgstr "Ви не увійшли в систему."
 
-#, fuzzy
-#| msgid "No Attachment found matching the query."
 msgid "No stage found matching the query."
-msgstr "Вкладень, що відповідають запиту, не знайдено."
+msgstr "Етапів за цим запитом не знайдено."
 
-#, fuzzy
-#| msgid "Stage updated."
 msgid "Stage Updated"
 msgstr "Етап оновлено."
 
-#, fuzzy
-#| msgid "Stage updated."
 msgid "Stage not updated"
-msgstr "Етап оновлено."
+msgstr "Етап не оновлено"
 
-#, fuzzy
-#| msgid "The specified project does not exist."
 msgid "Requested object does not exist"
-msgstr "Вказаний проєкт не існує."
+msgstr "Запитаний об'єкт не існує"
 
-#, fuzzy
-#| msgid "Allocated"
 msgid "Task Allocated"
-msgstr "Розподілено"
+msgstr "Завдання призначено"
 
-#, fuzzy
-#| msgid "Stage updated."
 msgid "Status updated"
-msgstr "Етап оновлено."
+msgstr "Статус оновлено"
 
 msgid "Full Name"
 msgstr "Повне ім'я"
@@ -17721,6 +15556,8 @@ msgstr "Назва завдання"
 msgid ""
 "Required tasks must be completed by the candidate to move to the next stage."
 msgstr ""
+"Обов'язкові завдання мусять бути виконані кандидатом для переходу на "
+"наступний етап."
 
 msgid "Onboarding Task"
 msgstr "Завдання адаптації"
@@ -17734,42 +15571,30 @@ msgstr "Кандидат на адаптацію"
 msgid "Candidate Onboarding Stage"
 msgstr "Етап адаптації кандидата"
 
-#, fuzzy
-#| msgid "Do you want to delete this candidate?"
 msgid "Do you want to undo rejection for this candidate?"
-msgstr "Бажаєте видалити цього кандидата?"
+msgstr "Ви бажаєте скасувати відхилення цього кандидата?"
 
-#, fuzzy
-#| msgid "Rejected Candidate"
 msgid "Undo Rejected Candidate"
-msgstr "Відхилений кандидат"
+msgstr "Скасувати відхилення кандидата"
 
 msgid "Add To Rejected Candidates"
 msgstr "Додати до відхилених кандидатів"
 
-#, fuzzy
-#| msgid "Do you want to delete this candidate?"
 msgid "Do you want to add this candidate to onboarding stage?"
-msgstr "Бажаєте видалити цього кандидата?"
+msgstr "Ви бажаєте додати цього кандидата на етап адаптації?"
 
 #| msgid "Start Onboard"
 msgid "Start Onboarding"
 msgstr "Почати онбординг"
 
-#, fuzzy
-#| msgid "Add to offboarding"
 msgid "Added to Onobarding"
-msgstr "Додати до звільнення"
+msgstr "Додано до адаптації"
 
-#, fuzzy
-#| msgid "Already Returned"
 msgid "Already Added!"
-msgstr "Вже повернувся"
+msgstr "Вже додано!"
 
-#, fuzzy
-#| msgid "Candidate Added to Onboarding Stage"
 msgid "Candidate already added to onboarding"
-msgstr "Кандидата додано до етапу адаптації"
+msgstr "Кандидата вже додано до адаптації"
 
 msgid "Send Portal / Start Onboarding"
 msgstr "Надіслати портал / Почати адаптацію"
@@ -17798,10 +15623,8 @@ msgstr "Необов'язково"
 msgid "Template as Attachments"
 msgstr "Шаблон як вкладення"
 
-#, fuzzy
-#| msgid "Send Portal / Start Onboarding"
 msgid "Send portal link / Trigger Onboarding"
-msgstr "Надіслати портал / Почати адаптацію"
+msgstr "Надіслати посилання на портал / запустити адаптацію"
 
 msgid "Send Portal Link"
 msgstr "Надіслати посилання на портал"
@@ -17816,7 +15639,7 @@ msgid "Till End Date"
 msgstr "До дати завершення"
 
 msgid "Taks"
-msgstr ""
+msgstr "Завдання"
 
 msgid "Upload Resumes"
 msgstr "Завантажити резюме"
@@ -17851,66 +15674,44 @@ msgstr "Статус листа з пропозицією:"
 msgid "At present, There are no Candidates onboarding."
 msgstr "Наразі немає кандидатів на етапі адаптації."
 
-#, fuzzy
-#| msgid "view-onboarding-dashboard"
 msgid "Onboarding Dashboard"
-msgstr "view-onboarding-dashboard"
+msgstr "Дашборд адаптації"
 
-#, fuzzy
-#| msgid "Onboarding Stage"
 msgid "Onboarding Stage Pipeline"
-msgstr "Етап адаптації"
+msgstr "Воронка етапів адаптації"
 
-#, fuzzy
-#| msgid "Candidates Per Stage"
 msgid "Candidates per stage"
 msgstr "Кандидати за етапами"
 
-#, fuzzy
-#| msgid "Onboarding Tasks"
 msgid "All onboarding tasks"
-msgstr "Завдання адаптації"
+msgstr "Усі завдання адаптації"
 
-#, fuzzy
-#| msgid "Recruitment"
 msgid "By Recruitment"
-msgstr "Підбір персоналу"
+msgstr "За вакансією"
 
-#, fuzzy
-#| msgid "Candidates Per Stage"
 msgid "Candidates per recruitment"
-msgstr "Кандидати за етапами"
+msgstr "Кандидатів на вакансію"
 
-#, fuzzy
-#| msgid "Candidate Reports"
 msgid "Candidates per position"
-msgstr "Звіти по кандидатах"
+msgstr "Кандидатів на позицію"
 
-#, fuzzy
-#| msgid "Completion Date"
 msgid "Completion Trend"
-msgstr "Дата завершення"
+msgstr "Тенденція завершення"
 
 msgid "Onboarding completions — last 6 months"
-msgstr ""
+msgstr "Завершення адаптації — останні 6 місяців"
 
-#, fuzzy
-#| msgid "Tasks"
 msgid "My Tasks"
-msgstr "Завдання"
+msgstr "Мої завдання"
 
-#, fuzzy
-#| msgid "Portal Sent"
 msgid "Portal Access"
-msgstr "Портал надіслано"
+msgstr "Доступ до порталу"
 
-#, fuzzy
-#| msgid "Finish Onboarding"
 msgid "Finished onboarding"
-msgstr "Завершити адаптацію"
+msgstr "Адаптацію завершено"
 
 msgid "done"
-msgstr ""
+msgstr "виконано"
 
 msgid "Recruitments"
 msgstr "Підбір персоналу"
@@ -17918,43 +15719,29 @@ msgstr "Підбір персоналу"
 msgid "Active hiring"
 msgstr "Активний найм"
 
-#, fuzzy
-#| msgid "Onboarding Stages"
 msgid "No onboarding stages"
-msgstr "Етапи адаптації"
+msgstr "Немає етапів адаптації"
 
-#, fuzzy
-#| msgid "Completing"
 msgid "No completions"
-msgstr "Завершення"
+msgstr "Немає завершень"
 
-#, fuzzy
-#| msgid "Onboarding Candidates"
 msgid "No onboarding candidates"
-msgstr "Кандидати на онбординг"
+msgstr "Немає кандидатів на адаптації"
 
-#, fuzzy
-#| msgid "No assets have been assigned to you."
 msgid "No tasks assigned to you"
-msgstr "Вам не призначено жодних активів."
+msgstr "Вам не призначено завдань"
 
-#, fuzzy
-#| msgid "Export Data"
 msgid "No portal data"
-msgstr "Експорт даних"
+msgstr "Немає даних порталу"
 
 msgid "visits"
-msgstr ""
+msgstr "візити"
 
-#, fuzzy
-#| msgid "Not Marked"
 msgid "Not accessed"
-msgstr "Не позначено"
+msgstr "Не відкривали"
 
-#, fuzzy
-#| msgid "There are candidates in this stage..."
 msgid "candidates in this task"
-msgstr "На цьому етапі є кандидати..."
+msgstr "кандидатів у цьому завданні"
 
 msgid "Send Portal  / Start onboarding"
 msgstr "Надіслати портал / Розпочати адаптацію"
@@ -17962,10 +15749,9 @@ msgstr "Надіслати портал / Розпочати адаптацію"
 msgid "Do you want to delete this stage?"
 msgstr "Ви бажаєте видалити цей етап?"
 
-#, fuzzy, python-format
-#| msgid "Congratulation on your selection"
+#, python-format
 msgid "Hello %(instance_name)s, Congratulations on your selection!"
-msgstr "Вітаємо з обранням"
+msgstr "Вітаємо, %(instance_name)s! Поздоровляємо з вибором!"
 
 msgid ""
 "Your dedication is valued, and we wish you continued success. If you have "
@@ -18094,6 +15880,7 @@ msgstr "Фото профілю успішно оновлено.."
 
 msgid "Please create your account first before continuing employee creation."
 msgstr ""
+"Спершу створіть свій акаунт, перш ніж продовжити створення співробітника."
 
 msgid "Employee with email id already exists."
 msgstr "Співробітник із такою електронною поштою вже існує."
@@ -18104,14 +15891,14 @@ msgstr "Співробітник вже існує.."
 msgid ""
 "User account was not found. Please complete account creation and try again."
 msgstr ""
+"Акаунт користувача не знайдено. Завершіть створення акаунта й спробуйте "
+"знову."
 
 msgid "Employee personal details created successfully.."
 msgstr "Особисті дані співробітника успішно створено.."
 
-#, fuzzy
-#| msgid "Offboarding not found"
 msgid "Onboarding portal not found."
-msgstr "Звільнення не знайдено"
+msgstr "Портал адаптації не знайдено."
 
 msgid "Employee bank details created successfully.."
 msgstr "Банківські реквізити співробітника успішно створено.."
@@ -18119,10 +15906,8 @@ msgstr "Банківські реквізити співробітника ус�
 msgid "Candidate onboarding task updated"
 msgstr "Завдання адаптації кандидата оновлено"
 
-#, fuzzy
-#| msgid "Objective not found."
 msgid "Object not found."
-msgstr "Ціль не знайдено."
+msgstr "Об'єкт не знайдено."
 
 msgid "Candidate onboarding stage updated"
 msgstr "Етап адаптації кандидата оновлено"
@@ -18143,10 +15928,8 @@ msgstr "Дату виходу на роботу для {candidate} успішн�
 msgid "No candidates started onboarding...."
 msgstr "Жоден кандидат не розпочав адаптацію...."
 
-#, fuzzy
-#| msgid "Missing required parameters: sequence"
 msgid "Missing required parameter: sequenceData."
-msgstr "Відсутні необхідні параметри: послідовність"
+msgstr "Відсутній обов'язковий параметр: sequenceData."
 
 msgid "Candidate sequence updated"
 msgstr "Послідовність кандидатів оновлено"
@@ -18160,20 +15943,14 @@ msgstr "Назву етапу успішно оновлено"
 msgid "Probation end date updated"
 msgstr "Дату закінчення випробувального терміну оновлено"
 
-#, fuzzy
-#| msgid "candidate or status is missing"
 msgid "Task ID or status is missing"
-msgstr "кандидат або статус відсутній"
+msgstr "Відсутній ID або статус завдання"
 
-#, fuzzy
-#| msgid "Candidate not found"
 msgid "Candidate task not found"
-msgstr "Кандидата не знайдено"
+msgstr "Завдання кандидата не знайдено"
 
-#, fuzzy
-#| msgid "Task status changed successfully."
 msgid "Task status updated successfully."
-msgstr "Статус завдання успішно змінено."
+msgstr "Статус завдання успішно оновлено."
 
 msgid "candidate or status is missing"
 msgstr "кандидат або статус відсутній"
@@ -18184,20 +15961,14 @@ msgstr "Передайте дійсний статус"
 msgid "Status of offer letter updated successfully"
 msgstr "Статус листа-пропозиції успішно оновлено"
 
-#, fuzzy
-#| msgid "Candidate Reject Reason"
 msgid "Candidate reject reason saved"
-msgstr "Причина відхилення кандидата"
+msgstr "Причину відхилення кандидата збережено"
 
-#, fuzzy
-#| msgid "Candidate Does not exists."
 msgid "Candidate removed from rejected list"
-msgstr "Кандидат не існує."
+msgstr "Кандидата вилучено зі списку відхилених"
 
-#, fuzzy
-#| msgid "Candidate is Converted "
 msgid "Candidate is not in rejected list"
-msgstr "Кандидата конвертовано "
+msgstr "Кандидата немає у списку відхилених"
 
 msgid "No offer letters selected for status update."
 msgstr "Для оновлення статусу не вибрано листів із пропозиціями."
@@ -18283,50 +16054,32 @@ msgstr "Вирахувати з базової оплати"
 msgid "Pay Frequency"
 msgstr "Періодичність виплат"
 
-#, fuzzy
-#| msgid "Total Net Payable"
 msgid "Total Net Pay"
-msgstr "Загальна сума до виплати"
+msgstr "Разом до виплати"
 
-#, fuzzy
-#| msgid "End Date"
 msgid "Ending Date"
-msgstr "Дата закінчення"
+msgstr "Дата завершення"
 
-#, fuzzy
-#| msgid "Filing Status"
 msgid "Create Filing Status"
-msgstr "Статус подання"
+msgstr "Створити статус подання"
 
-#, fuzzy
-#| msgid "Filing Status"
 msgid "Update Filing Status"
-msgstr "Статус подання"
+msgstr "Оновити статус подання"
 
-#, fuzzy
-#| msgid "Filing status updated successfully."
 msgid "Filing Status Updated Successfully"
 msgstr "Статус подання успішно оновлено."
 
-#, fuzzy
-#| msgid "Filing status created successfully "
 msgid "Filing StatusCreated Successfully"
 msgstr "Статус подання успішно створено "
 
-#, fuzzy
-#| msgid "Tax Bracket"
 msgid "Tax Brackets"
-msgstr "Податкова ставка"
+msgstr "Податкові розряди"
 
-#, fuzzy
-#| msgid "Create Ticket"
 msgid "Create Tax Bracket"
-msgstr "Створити заявку"
+msgstr "Створити податковий розряд"
 
-#, fuzzy
-#| msgid "Update Ticket"
 msgid "Update Tax Bracket"
-msgstr "Оновити заявку"
+msgstr "Оновити податковий розряд"
 
 msgid "The maximum income will be infinite"
 msgstr "Максимальний дохід буде необмеженим"
@@ -18337,10 +16090,8 @@ msgstr "Податкову ставку успішно оновлено."
 msgid "The tax bracket was created successfully."
 msgstr "Податкову ставку успішно створено."
 
-#, fuzzy
-#| msgid "Tax Rate"
 msgid "Tax Rate (%)"
-msgstr "Податкова ставка"
+msgstr "Податкова ставка (%)"
 
 msgid "Min. Income"
 msgstr "Мін. дохід"
@@ -18360,25 +16111,17 @@ msgstr "Дата надання"
 msgid "Installment Start Date"
 msgstr "Дата початку виплат частинами"
 
-#, fuzzy
-#| msgid "Total Installments"
 msgid "Toatal Installments"
-msgstr "Загальна кількість платежів"
+msgstr "Усього платежів"
 
-#, fuzzy
-#| msgid "Progress"
 msgid "Progress Bar"
-msgstr "Прогрес"
+msgstr "Смуга прогресу"
 
-#, fuzzy
-#| msgid "Candidate Updated Successfully."
 msgid "Loan Updated Successfully"
-msgstr "Дані кандидата успішно оновлено."
+msgstr "Позику успішно оновлено"
 
-#, fuzzy
-#| msgid "New holiday created successfully.."
 msgid "New Loan Created Successfully"
-msgstr "Нове свято успішно створено.."
+msgstr "Нову позику успішно створено"
 
 msgid "Generate"
 msgstr "Створити"
@@ -18386,13 +16129,9 @@ msgstr "Створити"
 msgid "Payslip Report"
 msgstr "Звіт по розрахункових листках"
 
-#, fuzzy
-#| msgid "Send via mail"
 msgid "Send Via Mail"
 msgstr "Надіслати поштою"
 
-#, fuzzy
-#| msgid "Payslip Batch"
 msgid "Pay Slip Batch"
 msgstr "Пакет розрахункових листків"
 
@@ -18425,11 +16164,8 @@ msgstr "Оновити автоматичне створення розраху�
 msgid "All companies"
 msgstr "Усі компанії"
 
-#, fuzzy
-#| msgid "Active 'Payslip auto generate' cannot delete."
 msgid "Active 'Payslip auto generate' cannot be deleted."
-msgstr ""
-"Неможливо видалити активне 'Автоматичне формування розрахункового листа'."
+msgstr "Активну «Автогенерацію розрахункових листків» не можна видалити."
 
 msgid "Leave Encashments"
 msgstr "Компенсація невикористаної відпустки"
@@ -18446,25 +16182,17 @@ msgstr "Перенесення для компенсації"
 msgid "Bonus to encash"
 msgstr "Бонус для компенсації"
 
-#, fuzzy
-#| msgid "Create Reimbursement"
 msgid "Create Reimbursement / Encashment"
-msgstr "Створити відшкодування"
+msgstr "Створити компенсацію / відшкодування"
 
-#, fuzzy
-#| msgid "Create Reimbursement"
 msgid "Update Reimbursement / Encashment"
-msgstr "Створити відшкодування"
+msgstr "Оновити компенсацію / відшкодування"
 
-#, fuzzy
-#| msgid "Reimbursement saved successfully"
 msgid "Reimbursement updated successfully"
-msgstr "Відшкодування успішно збережено"
+msgstr "Компенсацію успішно оновлено"
 
-#, fuzzy
-#| msgid "Reimbursement saved successfully"
 msgid "Reimbursement created successfully"
-msgstr "Відшкодування успішно збережено"
+msgstr "Компенсацію успішно створено"
 
 msgid "Payslip Auto Generation"
 msgstr "Автоматичне створення розрахункового листа"
@@ -18510,10 +16238,8 @@ msgstr "Податковий код порожній."
 msgid "Value must be greater than zero"
 msgstr "Значення має бути більшим за нуль"
 
-#, fuzzy
-#| msgid "Bank Code"
 msgid "Python Code"
-msgstr "Код банку"
+msgstr "Код Python"
 
 msgid "Filing Statuses"
 msgstr "Статуси подання"
@@ -18577,10 +16303,8 @@ msgstr ""
 "Одноразова надбавка, яка застосовується до розрахункових листків, якщо дата "
 "потрапляє в період розрахункового листка"
 
-#, fuzzy
-#| msgid "Unselect All Employees"
 msgid "Include All Employees"
-msgstr "Скасувати вибір усіх співробітників"
+msgstr "Включити всіх співробітників"
 
 msgid "Target allowance to all active employees in the company"
 msgstr "Призначити надбавку всім активним співробітникам компанії"
@@ -18652,10 +16376,8 @@ msgstr "Обмежити суму надбавки"
 msgid "The maximum amount for the allowance"
 msgstr "Максимальна сума надбавки"
 
-#, fuzzy
-#| msgid "Paid Amount"
 msgid "Maximum Amount"
-msgstr "Сплачена сума"
+msgstr "Максимальна сума"
 
 msgid "For working days on month"
 msgstr "За робочі дні місяця"
@@ -18663,10 +16385,8 @@ msgstr "За робочі дні місяця"
 msgid "The maximum amount for ?"
 msgstr "Максимальна сума для ?"
 
-#, fuzzy
-#| msgid "Has Maximum Limit"
 msgid "Maximum Unit"
-msgstr "Має максимальний ліміт"
+msgstr "Максимальна одиниця"
 
 msgid "The pay head for the if condition"
 msgstr "Стаття виплат для умови if"
@@ -18683,10 +16403,8 @@ msgstr "Початкова сума діапазону статті виплат
 msgid "The end amount of the pay-head range"
 msgstr "Кінцева сума діапазону статті виплат"
 
-#, fuzzy
-#| msgid "Info"
 msgid "If"
-msgstr "Інформація"
+msgstr "Якщо"
 
 msgid "If the 'Is fixed' field is disabled, the 'Based on' field is required."
 msgstr "Якщо поле «Фіксована» вимкнено, поле «На основі» є обов'язковим."
@@ -18849,15 +16567,11 @@ msgstr "Загальна кількість платежів"
 msgid "From the start date deduction will apply"
 msgstr "Від дати початку буде застосовано відрахування"
 
-#, fuzzy
-#| msgid "Installment Start Date"
 msgid "Installment start date"
 msgstr "Дата початку виплат частинами"
 
-#, fuzzy
-#| msgid "Loan Settled"
 msgid "Settled"
-msgstr "Погашено"
+msgstr "Розраховано"
 
 msgid "Reimbursement"
 msgstr "Відшкодування"
@@ -18906,13 +16620,11 @@ msgid "On this day of every month,Payslip will auto generate"
 msgstr ""
 "У цей день кожного місяця розрахунковий лист буде згенеровано автоматично"
 
-#, fuzzy
-#| msgid "Auto generate"
 msgid "Auto Generate"
 msgstr "Автогенерація"
 
 msgid "Suffix"
-msgstr ""
+msgstr "Суфікс"
 
 msgid "Payroll Settings"
 msgstr "Налаштування зарплати"
@@ -18926,10 +16638,8 @@ msgstr "Ця податкова категорія вже існує"
 msgid "Maximum income must be greater than minimum income."
 msgstr "Максимальний дохід має бути більшим за мінімальний."
 
-#, fuzzy
-#| msgid "Reimbursements"
 msgid "Encashments & Reimbursements"
-msgstr "Компенсації витрат"
+msgstr "Компенсації та відшкодування"
 
 msgid "Encashment"
 msgstr "Інкасація"
@@ -18988,21 +16698,16 @@ msgstr "Базова зарплата менша або дорівнює"
 msgid "Basic Salary Greater or Equal"
 msgstr "Базова зарплата більша або дорівнює"
 
-#, fuzzy, python-format
-#| msgid "Tax Rate"
+#, python-format
 msgid "Tax Rate (%%)"
-msgstr "Податкова ставка"
+msgstr "Податкова ставка (%%)"
 
-#, fuzzy
-#| msgid "Attachments added"
 msgid "No tax brackets added"
-msgstr "Вкладення додано"
+msgstr "Податкові розряди не додані"
 
 msgid "out of"
-msgstr ""
+msgstr "з"
 
-#, fuzzy
-#| msgid "Installments"
 msgid "installments"
 msgstr "Платежі частинами"
 
@@ -19019,11 +16724,11 @@ msgid ""
 "Automatically generate payslips for employees on a scheduled day of the "
 "month."
 msgstr ""
+"Автоматично генерувати розрахункові листки для співробітників у заданий день"
+" місяця."
 
-#, fuzzy
-#| msgid "Do you want to send the payslip by mail?"
 msgid "Do you want to sent the payslip by mail?"
-msgstr "Бажаєте надіслати розрахунковий листок поштою?"
+msgstr "Ви бажаєте надіслати розрахунковий листок поштою?"
 
 msgid "Are you sure you want to delete this payslip?"
 msgstr "Ви впевнені, що бажаєте видалити цей розрахунковий листок?"
@@ -19064,10 +16769,8 @@ msgstr "Масове створення розрахункових листкі�
 msgid "Export Payslips"
 msgstr "Експортувати розрахункові листки"
 
-#, fuzzy
-#| msgid "Attachments"
 msgid "No Attachments."
-msgstr "Вкладення"
+msgstr "Немає вкладень."
 
 msgid "Add More"
 msgstr "Додати ще"
@@ -19078,8 +16781,6 @@ msgstr "Наразі немає надбавок для розгляду."
 msgid "There have been no contracts signed."
 msgstr "Немає підписаних контрактів."
 
-#, fuzzy
-#| msgid "Update"
 msgid " Update"
 msgstr "Оновити"
 
@@ -19140,16 +16841,16 @@ msgstr "Банк. рахунок/номер чека"
 msgid "taxable amount"
 msgstr "сума, що оподатковується"
 
-#, fuzzy
-#| msgid "Deduction not found"
 msgid "Deduction Amount"
-msgstr "Утримання не знайдено"
+msgstr "Сума утримання"
 
 #, python-format
 msgid ""
 "Partial deduction — %(partial_pay_days)s day(s) on a partially paid leave "
 "type"
 msgstr ""
+"Часткове утримання — %(partial_pay_days)s дн. за типом відпустки з частковою"
+" оплатою"
 
 msgid "Download report"
 msgstr "Завантажити звіт"
@@ -19172,20 +16873,14 @@ msgstr "Відділ:"
 msgid "Bank Acc./Cheque No :"
 msgstr "Банк. рахунок/номер чека:"
 
-#, fuzzy
-#| msgid "Paid Days"
 msgid "Paid Days :"
 msgstr "Оплачені дні"
 
-#, fuzzy
-#| msgid "LOP Days"
 msgid "LOP Days :"
 msgstr "Дні LOP"
 
-#, fuzzy
-#| msgid "Paid Days"
 msgid "Partially Paid Days :"
-msgstr "Оплачені дні"
+msgstr "Частково оплачені дні:"
 
 #, python-format
 msgid ""
@@ -19193,6 +16888,9 @@ msgid ""
 "                                                deduction — %(partial_pay_days)s day(s) on a partially paid leave\n"
 "                                                type"
 msgstr ""
+"Часткове\n"
+"                                                утримання — %(partial_pay_days)s дн. за типом відпустки з частковою\n"
+"                                                оплатою"
 
 msgid "Gross earning - Total Deduction"
 msgstr "Валовий дохід - загальні утримання"
@@ -19254,8 +16952,6 @@ msgstr "Ви впевнені, що хочете видалити цю пода�
 msgid "Allowance created."
 msgstr "Надбавку створено."
 
-#, fuzzy
-#| msgid "Allowance not found"
 msgid "Allowance not found."
 msgstr "Надбавку не знайдено"
 
@@ -19271,8 +16967,6 @@ msgstr "Надбавку не знайдено"
 msgid "Deduction created."
 msgstr "Утримання створено."
 
-#, fuzzy
-#| msgid "Deduction not found"
 msgid "Deduction not found."
 msgstr "Утримання не знайдено"
 
@@ -19311,6 +17005,8 @@ msgstr "Дата завершення має бути більшою або до
 
 msgid "Payslip data not found for the specified employee and date range."
 msgstr ""
+"Даних розрахункового листка для вказаного співробітника й періоду не "
+"знайдено."
 
 msgid "Email server is not configured"
 msgstr "Сервер електронної пошти не налаштовано"
@@ -19332,10 +17028,8 @@ msgstr ""
 msgid "Loan created/updated"
 msgstr "Позику створено/оновлено"
 
-#, fuzzy
-#| msgid "Note not found."
 msgid "Loan not found."
-msgstr "Примітку не знайдено."
+msgstr "Позику не знайдено."
 
 msgid "Loan account deleted"
 msgstr "Позиковий рахунок видалено"
@@ -19358,10 +17052,8 @@ msgstr "Перевірте надані дані."
 msgid "Reimbursements deleted"
 msgstr "Відшкодування видалено"
 
-#, fuzzy
-#| msgid "Shift request not found."
 msgid "Reimbursement request not found."
-msgstr "Запит на зміну не знайдено."
+msgstr "Заявку на компенсацію не знайдено."
 
 msgid "Attachment deleted"
 msgstr "Вкладення видалено"
@@ -19394,10 +17086,8 @@ msgstr "Податкову ставку не знайдено"
 msgid "Tax bracket successfully deleted."
 msgstr "Податкову ставку успішно видалено."
 
-#, fuzzy
-#| msgid "Invalid time"
 msgid "Invalid tax code"
-msgstr "Невірний час"
+msgstr "Невірний податковий код"
 
 msgid "Python code saved successfully!"
 msgstr "Код Python успішно збережено!"
@@ -19467,10 +17157,8 @@ msgstr "Розрахунковий лист {employee} за {period} видал�
 msgid "You cannot delete {payslip}"
 msgstr "Ви не можете видалити {payslip}"
 
-#, fuzzy
-#| msgid "No IDs provided."
 msgid "No IDs provided for deletion."
-msgstr "Не надано жодного ID."
+msgstr "Не надано ID для видалення."
 
 #, python-brace-format
 msgid "{name} deleted."
@@ -19480,38 +17168,26 @@ msgstr "{name} видалено."
 msgid "You cannot delete {contract}"
 msgstr "Ви не можете видалити {contract}"
 
-#, fuzzy
-#| msgid "Document not found"
 msgid "Comment not found."
-msgstr "Документ не знайдено"
+msgstr "Коментар не знайдено."
 
-#, fuzzy
-#| msgid "No candidates selected for deletion."
 msgid "No file IDs provided for deletion."
-msgstr "Немає кандидатів, обраних для видалення."
+msgstr "Не надано ID файлів для видалення."
 
-#, fuzzy
-#| msgid "Missing required parameter: ids"
 msgid "required parameter is missing"
-msgstr "Відсутній обов’язковий параметр: ідентифікатори"
+msgstr "відсутній обов'язковий параметр"
 
 msgid "The initial notice period has been successfully updated."
 msgstr "Початковий термін попередження успішно оновлено."
 
-#, fuzzy
-#| msgid "Created"
 msgid "created"
 msgstr "Створено"
 
-#, fuzzy
-#| msgid "Missing required parameters."
 msgid "Invalid request. Missing required parameters."
-msgstr "Відсутні необхідні параметри."
+msgstr "Невірний запит. Відсутні обов'язкові параметри."
 
-#, fuzzy
-#| msgid "Payslip auto generate not found."
 msgid "Payslip auto generate setting not found."
-msgstr "Автоматичне формування розрахункового листа не знайдено."
+msgstr "Налаштування автогенерації розрахункових листків не знайдено."
 
 msgid "Auto paslip generate activated successfully."
 msgstr "Автоматичне формування розрахункових листів успішно активовано."
@@ -19556,39 +17232,27 @@ msgstr "Запитаний відгук"
 msgid "Anonymous Feedback"
 msgstr "Анонімний відгук"
 
-#, fuzzy
-#| msgid "Anonymous"
 msgid "Add Anonymous"
-msgstr "Анонім"
+msgstr "Додати анонімно"
 
-#, fuzzy
-#| msgid "Feedbacks to review"
 msgid "Feedbacks to Review"
 msgstr "Відгуки на розгляд"
 
-#, fuzzy
-#| msgid "Bulk Feedback"
 msgid "Bulk feedback"
 msgstr "Масовий відгук"
 
 msgid "Feedbacks"
 msgstr "Відгуки"
 
-#, fuzzy
-#| msgid "Feedback updated successfully!."
 msgid "Feedback Updated Successfully"
 msgstr "Відгук успішно оновлено!."
 
-#, fuzzy
-#| msgid "Feedback created successfully."
 msgid "Feedback Created Successfully"
 msgstr "Відгук успішно створено."
 
 msgid "Update Feedback"
 msgstr "Оновити відгук"
 
-#, fuzzy
-#| msgid "Feedback updated successfully!."
 msgid "Feedback updated successfully!"
 msgstr "Відгук успішно оновлено!."
 
@@ -19601,15 +17265,11 @@ msgstr "Створити ключовий результат"
 msgid "Update Key result"
 msgstr "Оновити ключовий результат"
 
-#, fuzzy
-#| msgid "Key result Updated sucessfully."
 msgid "Ket result  deleted successfully!"
-msgstr "Ключовий результат успішно оновлено."
+msgstr "Ключовий результат успішно видалено!"
 
-#, fuzzy
-#| msgid "Leave request not found"
 msgid "Key result not found"
-msgstr "Заявку на відпустку не знайдено"
+msgstr "Ключовий результат не знайдено"
 
 msgid "MoM"
 msgstr "Протокол"
@@ -19617,38 +17277,26 @@ msgstr "Протокол"
 msgid "Meetings"
 msgstr "Зустрічі"
 
-#, fuzzy
-#| msgid "Update Request"
 msgid "Update Meeting"
-msgstr "Оновити запит"
+msgstr "Оновити зустріч"
 
 msgid "Meeting added successfully"
 msgstr "Зустріч успішно додано"
 
-#, fuzzy
-#| msgid "Response"
 msgid "Add Response"
-msgstr "Відповідь"
+msgstr "Додати відповідь"
 
-#, fuzzy
-#| msgid "Report added successfully."
 msgid "Response added successfully"
-msgstr "Звіт успішно додано."
+msgstr "Відповідь успішно додано"
 
-#, fuzzy
-#| msgid "All Objective"
 msgid "All Objectives"
 msgstr "Усі цілі"
 
-#, fuzzy
-#| msgid "Assigned Leaves"
 msgid "Assigned Objectives"
-msgstr "Призначені відпустки"
+msgstr "Призначені цілі"
 
-#, fuzzy
-#| msgid "Objective created"
 msgid "Objective Templates"
-msgstr "Ціль створено"
+msgstr "Шаблони цілей"
 
 msgid "Create Employee Objective"
 msgstr "Створити ціль співробітника"
@@ -19662,59 +17310,39 @@ msgstr "Ціль співробітника успішно оновлено"
 msgid "Employee objective created successfully"
 msgstr "Ціль співробітника успішно створено"
 
-#, fuzzy
-#| msgid "Create Objective"
 msgid "Create  Objective"
 msgstr "Створити ціль"
 
-#, fuzzy
-#| msgid "Objective deleted successfully!."
 msgid "Objective created successfully"
-msgstr "Ціль успішно видалено!."
+msgstr "Ціль успішно створено"
 
-#, fuzzy
-#| msgid "Objective deleted successfully!."
 msgid "Objective updated successfully"
-msgstr "Ціль успішно видалено!."
+msgstr "Ціль успішно оновлено"
 
 msgid "Update Objective"
 msgstr "Оновити ціль"
 
-#, fuzzy
-#| msgid "Create Objective"
 msgid "Create Objective Template"
-msgstr "Створити ціль"
+msgstr "Створити шаблон цілі"
 
-#, fuzzy
-#| msgid "Question template created successfully!"
 msgid "Objective template created successfully"
-msgstr "Шаблон запитань успішно створено!"
+msgstr "Шаблон цілі успішно створено"
 
-#, fuzzy
-#| msgid "Objective deleted successfully!."
 msgid "Objective template updated successfully"
-msgstr "Ціль успішно видалено!."
+msgstr "Шаблон цілі успішно оновлено"
 
-#, fuzzy
-#| msgid "You don't have permission for duplicate action."
 msgid "You don't have permission to perform this action"
-msgstr "У вас немає дозволу на дублювання."
+msgstr "У вас немає дозволу виконувати цю дію"
 
 msgid "Add assignees"
 msgstr "Додати виконавців"
 
-#, fuzzy
-#| msgid "Recruitment ID is missing"
 msgid "Objective ID is missing"
-msgstr "Відсутній ID набору"
+msgstr "Відсутній ID цілі"
 
-#, fuzzy
-#| msgid "Invalid time"
 msgid "Invalid Objective"
-msgstr "Невірний час"
+msgstr "Невірна ціль"
 
-#, fuzzy
-#| msgid "Key result Updated sucessfully."
 msgid "Key result updated sucessfully."
 msgstr "Ключовий результат успішно оновлено."
 
@@ -19733,38 +17361,24 @@ msgstr "Створити період"
 msgid "Update Period"
 msgstr "Оновити період"
 
-#, fuzzy
-#| msgid "Period updated  Successfully. "
 msgid "Period Updated Successfully"
 msgstr "Період успішно оновлено. "
 
-#, fuzzy
-#| msgid "Period updated  Successfully. "
 msgid "Period Created Successfully"
-msgstr "Період успішно оновлено. "
+msgstr "Період успішно створено"
 
-#, fuzzy
-#| msgid "Total Question"
 msgid "Total Questions"
 msgstr "Всього питань"
 
-#, fuzzy
-#| msgid "Question Template"
 msgid "Add Question Template"
-msgstr "Шаблон питання"
+msgstr "Додати шаблон питань"
 
-#, fuzzy
-#| msgid "Question Template"
 msgid "Edit Question Template"
-msgstr "Шаблон питання"
+msgstr "Редагувати шаблон питань"
 
-#, fuzzy
-#| msgid "Question template created successfully!"
 msgid "Question Template Updated Successfully"
-msgstr "Шаблон запитань успішно створено!"
+msgstr "Шаблон питань успішно оновлено"
 
-#, fuzzy
-#| msgid "Question template created successfully!"
 msgid "Question Template Created Successfully"
 msgstr "Шаблон запитань успішно створено!"
 
@@ -19786,25 +17400,17 @@ msgstr "Поділитися запитом на відгук "
 msgid "Bulk Feedback request "
 msgstr "Масовий запит на відгук "
 
-#, fuzzy
-#| msgid "Today"
 msgid "Due Today"
-msgstr "Сьогодні"
+msgstr "Дедлайн сьогодні"
 
-#, fuzzy
-#| msgid "This Week"
 msgid "Due This Week"
-msgstr "Цього тижня"
+msgstr "Дедлайн цього тижня"
 
-#, fuzzy
-#| msgid "This Month"
 msgid "Due This Month"
-msgstr "Цього місяця"
+msgstr "Дедлайн цього місяця"
 
-#, fuzzy
-#| msgid "Reset Month"
 msgid "Due Next Month"
-msgstr "Місяць скидання"
+msgstr "Дедлайн наступного місяця"
 
 msgid "The start date must be before the end date."
 msgstr "Дата початку має передувати даті завершення."
@@ -19859,13 +17465,16 @@ msgstr "Шаблон питання є обов'язковим, коли обр�
 
 msgid "For Objective and Key Result, 'Applicable For' must be 'Owner'."
 msgstr ""
+"Для цілі та ключового результату 'Застосовується до' мусить бути 'Власник'."
 
 msgid "For Objective and Key Result, 'Bonus For' must be 'Closing'."
-msgstr ""
+msgstr "Для цілі та ключового результату 'Бонус за' мусить бути 'Закриття'."
 
 msgid ""
 "For Task and Project, 'Applicable For' must be 'Members' or 'Managers'."
 msgstr ""
+"Для завдання та проєкту 'Застосовується до' мусить бути 'Учасники' або "
+"'Керівники'."
 
 msgid "Bonus point must be greater than zero"
 msgstr "Кількість бонусних балів має бути більшою за нуль"
@@ -19891,10 +17500,8 @@ msgstr "Включити всі ключові результати"
 msgid "Include all keyresults assigned to the employee."
 msgstr "Включити всі ключові результати, призначені працівнику."
 
-#, fuzzy
-#| msgid "Period 1"
 msgid "Period Name"
-msgstr "Період 1"
+msgstr "Назва періоду"
 
 msgid "Percentage"
 msgstr "Відсоток"
@@ -19902,10 +17509,8 @@ msgstr "Відсоток"
 msgid "Number"
 msgstr "Число"
 
-#, fuzzy
-#| msgid " Days"
 msgid "In Days"
-msgstr " Днів"
+msgstr "У днях"
 
 msgid "Months"
 msgstr "Місяці"
@@ -19913,15 +17518,11 @@ msgstr "Місяці"
 msgid "Years"
 msgstr "Роки"
 
-#, fuzzy
-#| msgid "Duration"
 msgid "Duration Unit"
-msgstr "Тривалість"
+msgstr "Одиниця тривалості"
 
-#, fuzzy
-#| msgid "Employee type updated."
 msgid "Self employee progress update"
-msgstr "Тип співробітника оновлено."
+msgstr "Оновлення прогресу самим співробітником"
 
 msgid "The target value can't be zero."
 msgstr "Цільове значення не може дорівнювати нулю."
@@ -19933,10 +17534,8 @@ msgstr ""
 "Тип прогресу ключового результату — відсоток, тому цільове значення не може "
 "перевищувати 100."
 
-#, fuzzy
-#| msgid "The current value can't be greater than target value."
 msgid "The start value can't be greater than current value or target value."
-msgstr "Поточне значення не може бути більшим за цільове значення."
+msgstr "Початкове значення не може перевищувати поточне або цільове значення."
 
 msgid "Text"
 msgstr "Текст"
@@ -19959,13 +17558,11 @@ msgstr "Працівники, для яких ініціатор запиту н
 msgid "Cycle Period"
 msgstr "Період циклу"
 
-#, fuzzy, python-format
-#| msgid "In %(days)s days"
+#, python-format
 msgid "Over due by %(days)s days"
-msgstr "Через %(days)s дн."
+msgstr "Прострочено на %(days)s дн."
 
-#, fuzzy, python-format
-#| msgid "In %(days)s days"
+#, python-format
 msgid "Due in %(days)s days"
 msgstr "Через %(days)s дн."
 
@@ -19991,35 +17588,23 @@ msgstr "Закриття"
 msgid "Completion Date"
 msgstr "Дата завершення"
 
-#, fuzzy
-#| msgid "Application Form"
 msgid "Applicable For"
-msgstr "Форма заявки"
+msgstr "Застосовується до"
 
-#, fuzzy
-#| msgid "Bonus"
 msgid "Bonus For"
-msgstr "Бонус"
+msgstr "Бонус за"
 
-#, fuzzy
-#| msgid "Field"
 msgid "Field 1"
-msgstr "Поле"
+msgstr "Поле 1"
 
-#, fuzzy
-#| msgid "Field"
 msgid "Field 2"
-msgstr "Поле"
+msgstr "Поле 2"
 
-#, fuzzy
-#| msgid "Points :"
 msgid "Points"
 msgstr "Бали:"
 
-#, fuzzy
-#| msgid "Feedback"
 msgid "360 Feedback"
-msgstr "Відгук"
+msgstr "360 Фідбек"
 
 msgid "Feedback Subject"
 msgstr "Тема відгуку"
@@ -20034,87 +17619,59 @@ msgid ""
 "Configure rules that automatically award bonus points to employees based on "
 "model events and conditions."
 msgstr ""
+"Налаштуйте правила автоматичного нарахування бонусних балів на основі подій "
+"моделей та умов."
 
 msgid "Do you want to delete the bonus point setting?"
 msgstr "Бажаєте видалити налаштування бонусних балів?"
 
-#, fuzzy
-#| msgid "Are you sure you want to remove this assignee?"
 msgid "Are you sure you want to Un-archive this feedback?"
-msgstr "Ви впевнені, що хочете видалити цього виконавця?"
+msgstr "Ви впевнені, що хочете розархівувати цей відгук?"
 
-#, fuzzy
-#| msgid "Are you sure you want to remove this assignee?"
 msgid "Are you sure you want to archive this feedback?"
-msgstr "Ви впевнені, що хочете видалити цього виконавця?"
+msgstr "Ви впевнені, що хочете заархівувати цей відгук?"
 
-#, fuzzy
-#| msgid "Already Returned"
 msgid "Already Answered"
-msgstr "Вже повернувся"
+msgstr "Вже відповіли"
 
 msgid "Can't delete the feedback it's already answered."
 msgstr "Неможливо видалити відгук, оскільки на нього вже надано відповідь."
 
-#, fuzzy
-#| msgid "Offboarding"
 msgid "In Offboarding?"
-msgstr "Звільнення"
+msgstr "В оффбордингу?"
 
-#, fuzzy
-#| msgid "Start Date"
 msgid "Start Date Range"
-msgstr "Дата початку"
+msgstr "Діапазон дат початку"
 
-#, fuzzy
-#| msgid "Date range"
 msgid "End Date Range"
-msgstr "Діапазон дат"
+msgstr "Діапазон дат завершення"
 
-#, fuzzy
-#| msgid "Created At"
 msgid "Created At Range"
-msgstr "Створено"
+msgstr "Діапазон створення"
 
-#, fuzzy
-#| msgid "Filters"
 msgid "Quick Filters"
-msgstr "Фільтри"
+msgstr "Швидкі фільтри"
 
-#, fuzzy
-#| msgid "Are you sure you want to delete\tthis Key result?"
 msgid "Are you sure you want to delete this Key result?"
 msgstr "Ви впевнені, що хочете видалити цей ключовий результат?"
 
-#, fuzzy
-#| msgid "Due"
 msgid "due"
 msgstr "Термін"
 
-#, fuzzy
-#| msgid "Fine"
 msgid "in"
-msgstr "Штраф"
+msgstr "в"
 
-#, fuzzy
-#| msgid "Do you want to unarchive this meeting?"
 msgid "Do you want to unarchive this key Result?"
-msgstr "Ви бажаєте розархівувати цю зустріч?"
+msgstr "Ви бажаєте розархівувати цей ключовий результат?"
 
-#, fuzzy
-#| msgid "Do you want to archive this ticket?"
 msgid "Do you want to archive this key Result?"
-msgstr "Бажаєте заархівувати цю заявку?"
+msgstr "Ви бажаєте заархівувати цей ключовий результат?"
 
-#, fuzzy
-#| msgid "Meeting"
 msgid "Join Meeting"
-msgstr "Зустріч"
+msgstr "Приєднатися до зустрічі"
 
-#, fuzzy
-#| msgid "Send Link"
 msgid "Send Meeting Link"
-msgstr "Надіслати посилання"
+msgstr "Надіслати посилання на зустріч"
 
 msgid "Add MoM"
 msgstr "Додати протокол"
@@ -20140,8 +17697,6 @@ msgstr "Дата менша або дорівнює"
 msgid "Are you sure to remove this manager?"
 msgstr "Ви впевнені, що хочете видалити цього керівника?"
 
-#, fuzzy
-#| msgid "Minutes of Meeting"
 msgid "Minutes Of Meeting"
 msgstr "Протокол зустрічі"
 
@@ -20151,10 +17706,8 @@ msgstr "Розархівувати цю ціль?"
 msgid "Do you want to archive this objective?"
 msgstr "Архівувати цю ціль?"
 
-#, fuzzy
-#| msgid "Are you sure you want to remove this assignee?"
 msgid "Are you sure want to remove this assignee?"
-msgstr "Ви впевнені, що хочете видалити цього виконавця?"
+msgstr "Ви впевнені, що хочете вилучити цього виконавця?"
 
 msgid "Do you want to Unarchive this Employee objective?"
 msgstr "Ви бажаєте розархівувати цю мету «Працівник»?"
@@ -20174,21 +17727,19 @@ msgstr "Ви впевнені, що хочете видалити цей клю�
 msgid "Are you sure want to remove this manager?"
 msgstr "Ви впевнені, що хочете видалити цього керівника?"
 
-#, fuzzy
-#| msgid "Create and manage reusable permission roles"
 msgid "Create and manage reusable objective templates for performance cycles."
-msgstr "Створюйте багаторазові ролі дозволів і керуйте ними"
+msgstr "Створюйте й керуйте шаблонами цілей для циклів продуктивності."
 
 msgid "Configure review periods that define key result tracking timelines."
 msgstr ""
+"Налаштуйте періоди огляду, що визначають терміни відстеження ключових "
+"результатів."
 
 msgid "Do you want to delete this question template?"
 msgstr "Ви бажаєте видалити цей шаблон питань?"
 
-#, fuzzy
-#| msgid "Question template is used in feedback."
 msgid "Define question templates used in 360 feedback and review meetings."
-msgstr "Шаблон запитань використовується у відгуку."
+msgstr "Визначте шаблони питань для 360-фідбеку та зустрічей-оглядів."
 
 msgid "Due Date"
 msgstr "Кінцевий термін"
@@ -20197,7 +17748,7 @@ msgid "Owner: "
 msgstr "Власник: "
 
 msgid "."
-msgstr ""
+msgstr "."
 
 msgid "Start date: "
 msgstr "Дата початку: "
@@ -20241,30 +17792,20 @@ msgstr "Немає доступних анонімних відгуків."
 msgid "Review Cycle"
 msgstr "Цикл оцінювання"
 
-#, fuzzy
-#| msgid "Question Type"
 msgid "Question type"
 msgstr "Тип питання"
 
-#, fuzzy
-#| msgid "Optional"
 msgid "Option a"
-msgstr "Необов'язково"
+msgstr "Варіант a"
 
-#, fuzzy
-#| msgid "Option"
 msgid "Option b"
-msgstr "Варіант"
+msgstr "Варіант b"
 
-#, fuzzy
-#| msgid "Option"
 msgid "Option c"
-msgstr "Варіант"
+msgstr "Варіант c"
 
-#, fuzzy
-#| msgid "Option"
 msgid "Option d"
-msgstr "Варіант"
+msgstr "Варіант d"
 
 msgid "Hide Questions"
 msgstr "Приховати питання"
@@ -20389,138 +17930,92 @@ msgstr "Немає."
 msgid "No time periods have been created."
 msgstr "Періоди часу ще не створені."
 
-#, fuzzy
-#| msgid "Performance Reports"
 msgid "Performance Dashboard"
-msgstr "Звіти по ефективності"
+msgstr "Дашборд продуктивності"
 
-#, fuzzy
-#| msgid "All Objective"
 msgid "All active objectives"
-msgstr "Усі цілі"
+msgstr "Усі активні цілі"
 
-#, fuzzy
-#| msgid "Total key results"
 msgid "All key results"
-msgstr "Загальна кількість ключових результатів"
+msgstr "Усі ключові результати"
 
 msgid "360° feedback cycles"
-msgstr ""
+msgstr "Цикли 360° фідбеку"
 
-#, fuzzy
-#| msgid "Department Leaves"
 msgid "Department Performance"
-msgstr "Відпустки відділу"
+msgstr "Продуктивність за відділами"
 
 msgid "Avg objective progress by department"
-msgstr ""
+msgstr "Сер. прогрес цілей за відділами"
 
-#, fuzzy
-#| msgid "Progress Percentage"
 msgid "OKR Progress Overview"
-msgstr "Відсоток виконання"
+msgstr "Огляд прогресу OKR"
 
 msgid "Top objectives with key result breakdown"
-msgstr ""
+msgstr "Топ цілей із розбивкою за ключовими результатами"
 
-#, fuzzy
-#| msgid "Progress Type"
 msgid "Progress Trend"
-msgstr "Тип прогресу"
+msgstr "Тенденція прогресу"
 
 msgid "Average objective progress — last 6 months"
-msgstr ""
+msgstr "Середній прогрес цілей — останні 6 місяців"
 
-#, fuzzy
-#| msgid "Feedback Description"
 msgid "Feedback Completion"
-msgstr "Опис відгуку"
+msgstr "Завершення відгуків"
 
 msgid "Answer completion rate per feedback cycle"
-msgstr ""
+msgstr "Рівень заповнення відповідей за циклами відгуків"
 
-#, fuzzy
-#| msgid "Objectives"
 msgid "At Risk Objectives"
-msgstr "Цілі"
+msgstr "Цілі під загрозою"
 
-#, fuzzy
-#| msgid "Performance"
 msgid "Top Performers"
-msgstr "Продуктивність"
+msgstr "Найкращі результати"
 
-#, fuzzy
-#| msgid "Upcoming holidays"
 msgid "Upcoming Meetings"
-msgstr "Найближчі свята"
+msgstr "Найближчі зустрічі"
 
-#, fuzzy
-#| msgid "Next Holiday"
 msgid "Next 14 days"
-msgstr "Наступне свято"
+msgstr "Наступні 14 днів"
 
-#, fuzzy
-#| msgid "Completed"
 msgid "completed"
 msgstr "Завершено"
 
-#, fuzzy
-#| msgid "Progress"
 msgid "Avg Progress"
-msgstr "Прогрес"
+msgstr "Сер. прогрес"
 
-#, fuzzy
-#| msgid "key result"
 msgid "key results"
-msgstr "ключовий результат"
+msgstr "ключові результати"
 
-#, fuzzy
-#| msgid "Objective created"
 msgid "Objectives need attention"
-msgstr "Ціль створено"
+msgstr "Цілі потребують уваги"
 
-#, fuzzy
-#| msgid "Pending"
 msgid "pending"
 msgstr "Очікується"
 
-#, fuzzy
-#| msgid "File Preview"
 msgid "All reviewed"
-msgstr "Попередній перегляд файлу"
+msgstr "Усі переглянуті"
 
-#, fuzzy
-#| msgid "Objectives"
 msgid "No objectives"
-msgstr "Цілі"
+msgstr "Немає цілей"
 
-#, fuzzy
-#| msgid "Total key results"
 msgid "No key results"
-msgstr "Загальна кількість ключових результатів"
+msgstr "Немає ключових результатів"
 
-#, fuzzy
-#| msgid "Total feedbacks"
 msgid "No feedback"
-msgstr "Загальна кількість відгуків"
+msgstr "Немає відгуків"
 
-#, fuzzy
-#| msgid "You have received feedback!"
 msgid "No active feedback cycles"
-msgstr "Ви отримали відгук!"
+msgstr "Немає активних циклів відгуків"
 
-#, fuzzy
-#| msgid "Update Objectives"
 msgid "No at-risk objectives"
-msgstr "Оновити цілі"
+msgstr "Немає цілей під загрозою"
 
 msgid "No upcoming meetings"
-msgstr ""
+msgstr "Немає найближчих зустрічей"
 
-#, fuzzy
-#| msgid "attendance"
 msgid "attendees"
-msgstr "відвідуваність"
+msgstr "учасники"
 
 msgid "Objective created"
 msgstr "Ціль створено"
@@ -20537,20 +18032,14 @@ msgstr "Ключовий результат %(key_result)s успішно ств
 msgid "Key result %(key_result)s updated successfully"
 msgstr "Ключовий результат %(key_result)s успішно оновлено"
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Key Result found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Ключових результатів за цим запитом не знайдено."
 
-#, fuzzy
-#| msgid "Meeting unarchived successfully"
 msgid "Key reuslt unarchived successfully"
-msgstr "Зустріч розархівовано"
+msgstr "Ключовий результат успішно розархівовано"
 
-#, fuzzy
-#| msgid "Meeting archived successfully"
 msgid "Key reuslt archived successfully"
-msgstr "Зустріч заархівовано"
+msgstr "Ключовий результат успішно заархівовано"
 
 #, python-format
 msgid "Objective %(objective)s deleted"
@@ -20560,25 +18049,17 @@ msgstr "Ціль %(objective)s видалено"
 msgid "You can't delete objective %(objective)s,related entries exists"
 msgstr "Неможливо видалити ціль %(objective)s, існують пов'язані записи"
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Objective found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Цілей за цим запитом не знайдено."
 
-#, fuzzy
-#| msgid "Stage manager removed successfully."
 msgid "Manger removed successfully."
-msgstr "Менеджера етапу успішно видалено."
+msgstr "Керівника успішно вилучено."
 
-#, fuzzy
-#| msgid "Key result Updated sucessfully."
 msgid "Key result removed successfully."
-msgstr "Ключовий результат успішно оновлено."
+msgstr "Ключовий результат успішно вилучено."
 
-#, fuzzy
-#| msgid "Asset created successfully"
 msgid "Assignee removed successfully."
-msgstr "Актив успішно створено"
+msgstr "Виконавця успішно вилучено."
 
 #, python-format
 msgid "Objective %(objective)s status updated"
@@ -20603,10 +18084,8 @@ msgstr "Ціль успішно розархівовано!."
 msgid "Objective archived successfully!."
 msgstr "Ціль успішно заархівовано!."
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Employee Objective found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Цілей співробітників за цим запитом не знайдено."
 
 msgid "You can't delete this objective,related entries exists"
 msgstr "Неможливо видалити цю ціль, існують пов'язані записи"
@@ -20617,10 +18096,8 @@ msgstr "Ціль успішно видалено!."
 msgid "The status of the objective is the same as selected."
 msgstr "Статус цілі збігається з обраним."
 
-#, fuzzy
-#| msgid "Invalid request"
 msgid "Invalid parameters"
-msgstr "Недійсний запит"
+msgstr "Невірні параметри"
 
 msgid "Key result created"
 msgstr "Ключовий результат створено"
@@ -20640,23 +18117,18 @@ msgstr "Поточний відгук не можна редагувати!."
 msgid "Feedback updated successfully!."
 msgstr "Відгук успішно оновлено!."
 
-#, fuzzy
-#| msgid "No Attachment found matching the query."
 msgid "No Feedback found matching the query."
-msgstr "Вкладень, що відповідають запиту, не знайдено."
+msgstr "Відгуків за цим запитом не знайдено."
 
-#, fuzzy, python-format
-#| msgid "No Document found matching the query."
+#, python-format
 msgid "No %(class_name)s found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "%(class_name)s за цим запитом не знайдено."
 
 msgid "Feedback not started yet"
 msgstr "Відгук ще не розпочато"
 
-#, fuzzy
-#| msgid "Feedback is due"
 msgid "Feedback is due/closed"
-msgstr "Термін відгуку настав"
+msgstr "Відгук прострочений/закритий"
 
 msgid "You are not allowed to answer"
 msgstr "Вам не дозволено відповідати"
@@ -20690,10 +18162,8 @@ msgstr "Статус відгуку оновлено на %(status)s"
 msgid "Error occurred during status update to %(status)s"
 msgstr "Під час оновлення статусу на %(status)s сталася помилка"
 
-#, fuzzy
-#| msgid "Attendance Does not exists.."
 msgid "Feedback does not exist."
-msgstr "Відвідуваність не існує.."
+msgstr "Відгук не існує."
 
 msgid "Feedback un-archived successfully!."
 msgstr "Відгук успішно розархівовано!."
@@ -20713,10 +18183,8 @@ msgstr "Запитання успішно створено."
 msgid "Error occurred during question creation!"
 msgstr "Під час створення запитання сталася помилка!"
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Question Template found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Шаблонів питань за цим запитом не знайдено."
 
 msgid "Question updated successfully."
 msgstr "Запитання успішно оновлено."
@@ -20788,10 +18256,8 @@ msgstr "Відгук не знайдено."
 msgid "You are don't have permissions."
 msgstr "У вас немає дозволів."
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Anonymous Feedback found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Анонімних відгуків за цим запитом не знайдено."
 
 msgid "Feedback deleted successfully!"
 msgstr "Відгук успішно видалено!"
@@ -20802,10 +18268,8 @@ msgstr "Не вдалося видалити відгук: шаблон відг
 msgid "Key result Updated sucessfully."
 msgstr "Ключовий результат успішно оновлено."
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Employee Key Result found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Ключових результатів співробітника за цим запитом не знайдено."
 
 msgid "Key result sattus changed to {}."
 msgstr "Статус ключового результату змінено на {}."
@@ -20816,10 +18280,8 @@ msgstr "Значення оновлено"
 msgid "You dont have permission to update the current value"
 msgstr "Ви не маєте дозволу оновлювати поточне значення"
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Meetings found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Зустрічей за цим запитом не знайдено."
 
 msgid "Meeting unarchived successfully"
 msgstr "Зустріч розархівовано"
@@ -20843,10 +18305,8 @@ msgstr "Запитання для зустрічі %(meeting)s успішно о
 msgid "Bonus Point Setting deleted"
 msgstr "Налаштування бонусних балів видалено"
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Bonus Point Setting found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Налаштувань бонусних балів за цим запитом не знайдено."
 
 msgid "Bonus point setting activated successfully."
 msgstr "Налаштування бонусних балів успішно активовано."
@@ -20878,13 +18338,9 @@ msgstr "Проєкти"
 msgid "To Do"
 msgstr "До виконання"
 
-#, fuzzy
-#| msgid "Please set up Google Drive backup first."
 msgid "Please create a project first."
-msgstr "Будь ласка, спочатку налаштуйте резервне копіювання на Google Диск."
+msgstr "Спершу створіть проєкт."
 
-#, fuzzy
-#| msgid "Project not found"
 msgid "Project not found."
 msgstr "Проект не знайдено"
 
@@ -21022,72 +18478,50 @@ msgstr "Бажаєте видалити це завдання?"
 msgid " Add"
 msgstr " Додати"
 
-#, fuzzy
-#| msgid "project-dashboard-view"
 msgid "Project Dashboard"
-msgstr "перегляд дашборду проєкту"
+msgstr "Дашборд проєктів"
 
 msgid "Distribution by status"
-msgstr ""
+msgstr "Розподіл за статусом"
 
-#, fuzzy
-#| msgid "End date breakdown"
 msgid "All tasks breakdown"
-msgstr "Розбивка дати закінчення"
+msgstr "Розбивка всіх завдань"
 
-#, fuzzy
-#| msgid "Project not found"
 msgid "Project Activity Trend"
-msgstr "Проект не знайдено"
+msgstr "Тенденція активності проєктів"
 
 msgid "Projects started vs completed over last 6 months"
-msgstr ""
+msgstr "Розпочаті та завершені проєкти за останні 6 місяців"
 
-#, fuzzy
-#| msgid "Upcoming holidays"
 msgid "Upcoming Deadlines"
-msgstr "Найближчі свята"
+msgstr "Найближчі дедлайни"
 
-#, fuzzy
-#| msgid "Projects due in this month"
 msgid "Projects due in next 30 days"
-msgstr "Проєкти з терміном виконання цього місяця"
+msgstr "Проєкти з дедлайном у 30 днів"
 
-#, fuzzy
-#| msgid "Total Projects"
 msgid "Top Active Projects"
-msgstr "Усього проєктів"
+msgstr "Топ активних проєктів"
 
-#, fuzzy
-#| msgid "Bank Country"
 msgid "By task count"
-msgstr "Країна банку"
+msgstr "За кількістю завдань"
 
-#, fuzzy
-#| msgid "Contract end date"
 msgid "Past end date"
-msgstr "Дата закінчення контракту"
+msgstr "Після дати завершення"
 
-#, fuzzy
-#| msgid "Task updated"
 msgid "Last updated"
-msgstr "Завдання оновлено"
+msgstr "Останнє оновлення"
 
-#, fuzzy
-#| msgid "Start"
 msgid "Started"
-msgstr "Почати"
+msgstr "Розпочато"
 
 msgid "No upcoming deadlines"
-msgstr ""
+msgstr "Немає найближчих дедлайнів"
 
 msgid "Due"
 msgstr "Термін"
 
-#, fuzzy
-#| msgid "New Projects"
 msgid "No active projects"
-msgstr "Нові проєкти"
+msgstr "Немає активних проєктів"
 
 msgid "Project manager"
 msgstr "Керівник проєкту"
@@ -21276,10 +18710,8 @@ msgstr "Відсутні необхідні параметри: project_id."
 msgid "Invalid selection"
 msgstr "Невірний вибір"
 
-#, fuzzy
-#| msgid "This leave type does not exist."
 msgid "Timesheet doesn't exist."
-msgstr "Цього типу відпустки не існує."
+msgstr "Табеля не існує."
 
 msgid "No ids provided."
 msgstr "Ідентифікатори не надано."
@@ -21301,36 +18733,24 @@ msgstr "Опитування"
 msgid "Are you sure want to delete this reason?"
 msgstr "Ви впевнені, що хочете видалити цю причину?"
 
-#, fuzzy
-#| msgid "Candidate Reject Reason"
 msgid "Create reject reason"
-msgstr "Причина відхилення кандидата"
+msgstr "Створити причину відхилення"
 
-#, fuzzy
-#| msgid "Candidate Reject Reason"
 msgid "Update reject reason"
-msgstr "Причина відхилення кандидата"
+msgstr "Оновити причину відхилення"
 
-#, fuzzy
-#| msgid "Question updated successfully."
 msgid "Reject reason updated successfully."
-msgstr "Запитання успішно оновлено."
+msgstr "Причину відхилення успішно оновлено."
 
-#, fuzzy
-#| msgid "Question created successfully."
 msgid "Reject reason created successfully."
-msgstr "Запитання успішно створено."
+msgstr "Причину відхилення успішно створено."
 
-#, fuzzy
-#| msgid "Fine Date"
 msgid "Hired Date"
-msgstr "Дата штрафу"
+msgstr "Дата найму"
 
 msgid "Scheduled Interview"
 msgstr "Запланована співбесіда"
 
-#, fuzzy
-#| msgid "Not-Hired"
 msgid "Not Hired"
 msgstr "Не найнято"
 
@@ -21352,39 +18772,27 @@ msgstr "Редагувати відхиленого кандидата"
 msgid "Create document request"
 msgstr "Створити запит документа"
 
-#, fuzzy
-#| msgid "Date of joining"
 msgid "Date joining"
-msgstr "Дата прийому на роботу"
+msgstr "Дата прийому"
 
-#, fuzzy
-#| msgid "Reject Reason"
 msgid "Reject reason"
 msgstr "Причина відхилення"
 
-#, fuzzy
-#| msgid "Skill Zone"
 msgid "Skill zone"
 msgstr "Зона навичок"
 
-#, fuzzy
-#| msgid "Interview Time"
 msgid "Interview Table"
-msgstr "Час співбесіди"
+msgstr "Таблиця співбесід"
 
 msgid "Add To Skill Zone"
 msgstr "Додати до зони навичок"
 
-#, fuzzy
-#| msgid "Candidates"
 msgid "No. of Candidates"
-msgstr "Кандидати"
+msgstr "Кількість кандидатів"
 
 msgid "Initial"
 msgstr "Початковий"
 
-#, fuzzy
-#| msgid "Recruitment"
 msgid "Recrutment"
 msgstr "Підбір персоналу"
 
@@ -21394,15 +18802,11 @@ msgstr "Дата співбесіди"
 msgid "Interview Time"
 msgstr "Час співбесіди"
 
-#, fuzzy
-#| msgid "Interview updated successfully."
 msgid "Interview Updated Successfully"
 msgstr "Інтерв'ю успішно оновлено."
 
-#, fuzzy
-#| msgid "Interview deleted successfully."
 msgid "Interview Scheduled successfully."
-msgstr "Співбесіду успішно видалено."
+msgstr "Співбесіду успішно заплановано."
 
 msgid "Resume Shortlisting"
 msgstr "Відбір резюме"
@@ -21410,124 +18814,84 @@ msgstr "Відбір резюме"
 msgid "Reopen"
 msgstr "Відкрити знову"
 
-#, fuzzy
-#| msgid "Rejected Candidate"
 msgid "Reject Candidate"
-msgstr "Відхилений кандидат"
+msgstr "Відхилити кандидата"
 
-#, fuzzy
-#| msgid "Hide Questions"
 msgid "Survey Questions"
-msgstr "Приховати питання"
+msgstr "Питання опитування"
 
-#, fuzzy
-#| msgid "Create survey questions"
 msgid "Update Survey Questions"
-msgstr "Створити питання опитування"
+msgstr "Оновити питання опитування"
 
-#, fuzzy
-#| msgid "New survey question updated."
 msgid "Survey question updated."
-msgstr "Нове питання опитування оновлено."
+msgstr "Питання опитування оновлено."
 
 msgid "New survey question created."
 msgstr "Нове питання опитування створено."
 
-#, fuzzy
-#| msgid "Duplicate Survey Template"
 msgid "Duplicate Survey Questions"
-msgstr "Дублювати шаблон опитування"
+msgstr "Дублювати питання опитування"
 
-#, fuzzy
-#| msgid "Template updated"
 msgid "Template saved"
-msgstr "Шаблон оновлено"
+msgstr "Шаблон збережено"
 
 msgid "Sequence"
 msgstr "Послідовність"
 
-#, fuzzy
-#| msgid "Vacancy"
 msgid "Vaccancy"
 msgstr "Вакансія"
 
 msgid "Total Hires"
 msgstr "Всього найнято"
 
-#, fuzzy
-#| msgid "Is Published"
 msgid "Is Published?"
 msgstr "Опубліковано"
 
-#, fuzzy
-#| msgid "Optional Profile Image"
 msgid "Optional Profile Image?"
 msgstr "Необов'язкове фото профілю"
 
-#, fuzzy
-#| msgid "Optional Resume"
 msgid "Optional Resume?"
 msgstr "Необов'язкове резюме"
 
 msgid "Skills"
 msgstr "Навички"
 
-#, fuzzy
-#| msgid "Skill created successfully"
 msgid "New Skill Created Successfully"
-msgstr "Навички створено успішно"
+msgstr "Нову навичку успішно створено"
 
 msgid "Add Recruitment"
 msgstr "Додати набір"
 
-#, fuzzy
-#| msgid "Request Updated Successfully"
 msgid "Recruitment Updated Successfully"
-msgstr "Запит успішно оновлено"
+msgstr "Вакансію успішно оновлено"
 
-#, fuzzy
-#| msgid "Recruitment reopend successfully"
 msgid "Recruitment Created Successfully"
-msgstr "Набір успішно відновлено"
+msgstr "Вакансію успішно створено"
 
-#, fuzzy
-#| msgid "Candidate added successfully."
 msgid "Candidate Added successfully."
 msgstr "Кандидата успішно додано."
 
-#, fuzzy
-#| msgid "Recruitment added."
 msgid "Recruitment added"
 msgstr "Набір додано."
 
 msgid "Skill"
 msgstr "Навичка"
 
-#, fuzzy
-#| msgid "Skill Zone"
 msgid "Create Skill Zone"
-msgstr "Зона навичок"
+msgstr "Створити зону навичок"
 
-#, fuzzy
-#| msgid "Add to Skill Zone"
 msgid "Update Skill Zone"
-msgstr "Додати до зони навичок"
+msgstr "Оновити зону навичок"
 
 msgid "Skill Zone updated successfully."
 msgstr "Зону навичок успішно оновлено."
 
-#, fuzzy
-#| msgid "Skill Zone created successfully."
 msgid "Skill Zone created successfully"
 msgstr "Зону навичок успішно створено."
 
-#, fuzzy
-#| msgid "Add Candidates"
 msgid "Add Candidate to  skill zone"
-msgstr "Додати кандидата"
+msgstr "Додати кандидата до зони навичок"
 
-#, fuzzy
-#| msgid "Candidate Updated Successfully."
 msgid "Candidate updated successfully."
 msgstr "Дані кандидата успішно оновлено."
 
@@ -21537,48 +18901,32 @@ msgstr "Кандидата успішно додано."
 msgid "Are you sure want to delete this skill?"
 msgstr "Ви впевнені, що хочете видалити цю навичку?"
 
-#, fuzzy
-#| msgid "Update Task"
 msgid "Update Skills"
-msgstr "Оновити завдання"
+msgstr "Оновити навички"
 
-#, fuzzy
-#| msgid "Shift updated"
 msgid "Skill updated"
-msgstr "Зміну оновлено"
+msgstr "Навичку оновлено"
 
-#, fuzzy
-#| msgid "Skill created successfully"
 msgid "Skill created successfully!"
 msgstr "Навички створено успішно"
 
-#, fuzzy
-#| msgid "Old Stage"
 msgid "Edit Stage"
-msgstr "Попередній етап"
+msgstr "Редагувати етап"
 
-#, fuzzy
-#| msgid "Stage updated."
 msgid "Stage updated"
 msgstr "Етап оновлено."
 
-#, fuzzy
-#| msgid "Stage added."
 msgid "Stage added"
 msgstr "Етап додано."
 
 msgid "LinkedIn Accounts"
 msgstr "Облікові записи LinkedIn"
 
-#, fuzzy
-#| msgid "Survey Filter"
 msgid "Survey Answer By"
-msgstr "Фільтр опитування"
+msgstr "Хто відповів на опитування"
 
-#, fuzzy
-#| msgid "Select all users"
 msgid "Select survey answers..."
-msgstr "Вибрати всіх користувачів"
+msgstr "Виберіть відповіді опитування..."
 
 msgid "---Choose Skills---"
 msgstr "---Оберіть навички---"
@@ -21685,10 +19033,8 @@ msgstr "Конвертовано"
 msgid "Employee is uniques for candidate"
 msgstr "Співробітник унікальний для кандидата"
 
-#, fuzzy
-#| msgid "Reason"
 msgid "No Reason"
-msgstr "Причина"
+msgstr "Без причини"
 
 msgid "Yes/No"
 msgstr "Так/Ні"
@@ -21751,7 +19097,7 @@ msgid "Profile"
 msgstr "Профіль"
 
 msgid "e.g. Jane Doe"
-msgstr ""
+msgstr "напр. Олена Коваль"
 
 msgid "Open Recruitment"
 msgstr "Відкритий набір"
@@ -21798,10 +19144,8 @@ msgstr "Кандидата конвертовано "
 msgid "To Skill zone"
 msgstr "До зони навичок"
 
-#, fuzzy
-#| msgid "Are you sure you want to delete this project?"
 msgid "Are you sure you want to cancel this rejection?"
-msgstr "Ви впевнені, що хочете видалити цей проєкт?"
+msgstr "Ви впевнені, що хочете скасувати це відхилення?"
 
 msgid "Cancel Rejection"
 msgstr "Скасувати відхилення"
@@ -21831,18 +19175,16 @@ msgid "Not-Hired"
 msgstr "Не найнято"
 
 msgid "Example: Candidate requested salary details before next round."
-msgstr ""
+msgstr "Приклад: кандидат запитав деталі зарплати перед наступним етапом."
 
 msgid "Write clear notes for future follow-up with the hiring team."
-msgstr ""
+msgstr "Пишіть чіткі нотатки для подальшої роботи з командою найму."
 
-#, fuzzy
-#| msgid "No notes have been added for this candidate"
 msgid "No notes yet for this candidate"
-msgstr "Для цього кандидата не додано жодної нотатки"
+msgstr "Нотаток для цього кандидата ще немає"
 
 msgid "Add a quick note above to keep the team aligned."
-msgstr ""
+msgstr "Додайте коротку нотатку вище, щоб команда була в курсі."
 
 msgid "Are you sure you want to remove this interviewer?"
 msgstr "Ви впевнені, що хочете видалити цього інтерв'юера?"
@@ -21859,8 +19201,6 @@ msgstr " Ви впевнені, що хочете видалити цю спів
 msgid "No Interviews Found."
 msgstr "Співбесід не знайдено."
 
-#, fuzzy
-#| msgid " There are no ratings to display at the moment."
 msgid "There are no ratings to display at the moment."
 msgstr " Наразі немає оцінок для відображення."
 
@@ -21879,35 +19219,25 @@ msgstr "Реєстрацію успішно завершено"
 msgid ""
 "Your details have been registered successfully. Feel free to close this "
 "window."
-msgstr ""
+msgstr "Ваші дані успішно зареєстровано. Можете закрити це вікно."
 
 msgid "Return home"
 msgstr "Повернутися на головну"
 
-#, fuzzy
-#| msgid "Recruitment managers"
 msgid "Recruitment Managers"
 msgstr "Менеджери з підбору персоналу"
 
-#, fuzzy
-#| msgid "Question Type"
 msgid "Question & Response"
-msgstr "Тип питання"
+msgstr "Питання та відповідь"
 
-#, fuzzy
-#| msgid "Scheduled from"
 msgid "Scheduled From"
 msgstr "Заплановано з"
 
-#, fuzzy
-#| msgid "Scheduled till"
 msgid "Scheduled Till"
 msgstr "Заплановано до"
 
-#, fuzzy
-#| msgid "There are no assignees for this objective at the moment."
 msgid "There are no tasks assigned for this candidate."
-msgstr "Наразі для цієї цілі немає виконавців."
+msgstr "Для цього кандидата завдань не призначено."
 
 msgid "This candidate does not have a resume on file."
 msgstr "У цього кандидата немає резюме в системі."
@@ -21916,65 +19246,49 @@ msgid "No survey templates have been established yet."
 msgstr "Ще не створено жодного шаблону опитування."
 
 msgid "chevron down outline"
-msgstr ""
+msgstr "chevron down outline"
 
-#, fuzzy
-#| msgid "create outline"
 msgid "chevron up outline"
-msgstr "create outline"
+msgstr "chevron up outline"
 
-#, fuzzy
-#| msgid "Interview Date"
 msgid "Interview Date From"
-msgstr "Дата співбесіди"
+msgstr "Дата співбесіди з"
 
-#, fuzzy
-#| msgid "Interview Date"
 msgid "Interview Date Till"
-msgstr "Дата співбесіди"
+msgstr "Дата співбесіди до"
 
 msgid "Interviews Scheduled"
 msgstr "Заплановані співбесіди"
 
-#, fuzzy
-#| msgid "Completed"
 msgid "Is Completed"
 msgstr "Завершено"
 
 msgid "Share Link"
 msgstr "Поширити посилання"
 
-#, fuzzy
-#| msgid "Are you sure you want to close this recruitment?"
 msgid "Are you sure you want to archive this recruitment?"
-msgstr "Ви впевнені, що хочете закрити цей набір?"
+msgstr "Ви впевнені, що хочете заархівувати цю вакансію?"
 
-#, fuzzy
-#| msgid "Are you sure you want to close this recruitment?"
 msgid "Are you sure you want to unarchive this recruitment?"
-msgstr "Ви впевнені, що хочете закрити цей набір?"
+msgstr "Ви впевнені, що хочете розархівувати цю вакансію?"
 
 msgid "Unknown"
 msgstr "Невідомо"
 
-#, fuzzy
-#| msgid "Are you sure you want to remove this department manager?"
 msgid "Are you sure you want to remove this recruitment manager?"
-msgstr "Ви впевнені, що хочете видалити цього керівника відділу?"
+msgstr "Ви впевнені, що хочете вилучити цього менеджера з підбору?"
 
 msgid "Jobs"
 msgstr "Вакансії"
 
 msgid "Define reasons for rejecting a candidate."
-msgstr ""
+msgstr "Визначте причини відхилення кандидатів."
 
 msgid "Manage the list of skills available for candidates and employees."
-msgstr ""
+msgstr "Керуйте списком навичок, доступних для кандидатів і співробітників."
 
-#, fuzzy
-#| msgid "Allow candidates to track their recruitment pipeline status"
 msgid "Define the recruitment pipeline stages."
-msgstr "Дозвольте кандидатам відстежувати статус свого набору персоналу"
+msgstr "Визначте етапи воронки підбору."
 
 msgid "Are sure want to remove this manager?"
 msgstr "Ви впевнені, що хочете видалити цього менеджера?"
@@ -22046,34 +19360,32 @@ msgid "Congrats..."
 msgstr "Вітаємо..."
 
 msgid "Example: Candidate asked to reschedule interview to Friday."
-msgstr ""
+msgstr "Приклад: кандидат попросив перенести співбесіду на п'ятницю."
 
 msgid ""
 "Notes are shared with your hiring team. Enable candidate visibility per note"
 " if needed."
 msgstr ""
+"Нотатки доступні вашій команді найму. За потреби вмикайте видимість для "
+"кандидата."
 
-#, fuzzy
-#| msgid "Mail sent to candidate"
 msgid "Visible to candidate"
-msgstr "Лист надіслано кандидату"
+msgstr "Видно кандидату"
 
-#, fuzzy
-#| msgid "Candidate can view this note"
 msgid "Candidate can't view this note"
-msgstr "Кандидат може переглядати цю примітку"
+msgstr "Кандидат не може бачити цю нотатку"
 
 msgid "Attach files to this note"
-msgstr ""
+msgstr "Прикріпити файли до цієї нотатки"
 
-#, fuzzy
-#| msgid "Attach Files"
 msgid "Attach files"
 msgstr "Прикріпити файли"
 
 msgid ""
 "Use the 'Add a note' field above to log interview updates or follow-ups."
 msgstr ""
+"Скористайтеся полем «Додати нотатку» вище, щоб фіксувати оновлення "
+"співбесід."
 
 msgid "Switch to Ongoing Recruitments"
 msgstr "Перейти до поточних наборів"
@@ -22093,201 +19405,138 @@ msgstr "Ви впевнені, що хочете закрити цей набі�
 msgid "Are you sure you want to reopen this recruitment?"
 msgstr "Ви впевнені, що хочете повторно відкрити цей набір?"
 
-#, fuzzy
-#| msgid "Recruitment manager"
 msgid "Recruitment Dashboard"
-msgstr "Менеджер з підбору персоналу"
+msgstr "Дашборд підбору"
 
-#, fuzzy
-#| msgid "Conversion Rate"
 msgid "Stage Conversion Funnel"
-msgstr "Коефіцієнт конверсії"
+msgstr "Воронка конверсії етапів"
 
 msgid "Drop-off rate between stages"
-msgstr ""
+msgstr "Втрати між етапами"
 
-#, fuzzy
-#| msgid "Candidates Per Stage"
 msgid "Candidates by Stage"
 msgstr "Кандидати за етапами"
 
-#, fuzzy
-#| msgid "View Recruitments"
 msgid "All active recruitments"
-msgstr "Переглянути набори"
+msgstr "Усі активні вакансії"
 
-#, fuzzy
-#| msgid "candidates"
 msgid "All candidates"
-msgstr "кандидати"
+msgstr "Усі кандидати"
 
-#, fuzzy
-#| msgid "Source"
 msgid "Source of Hire"
-msgstr "Джерело"
+msgstr "Джерело найму"
 
 msgid "Where candidates come from"
-msgstr ""
+msgstr "Звідки приходять кандидати"
 
-#, fuzzy
-#| msgid "Search in : Department"
 msgid "Open Positions by Department"
-msgstr "Пошук за: Відділ"
+msgstr "Відкриті вакансії за відділами"
 
 msgid "Filled vs open vacancies"
-msgstr ""
+msgstr "Заповнені та відкриті вакансії"
 
-#, fuzzy
-#| msgid "Current Hiring Pipeline"
 msgid "Hiring Pipeline"
-msgstr "Поточна воронка найму"
+msgstr "Воронка найму"
 
-#, fuzzy
-#| msgid "Candidate stage updated"
 msgid "Candidates per stage per recruitment"
-msgstr "Етап кандидата оновлено"
+msgstr "Кандидати за етапами по вакансіях"
 
-#, fuzzy
-#| msgid "Duplicate Recruitment"
 msgid "Hire Rate by Recruitment"
-msgstr "Дублювати набір"
+msgstr "Частка найму за вакансією"
 
-#, fuzzy
-#| msgid "Conversion Rate"
 msgid "Conversion efficiency"
-msgstr "Коефіцієнт конверсії"
+msgstr "Ефективність конверсії"
 
-#, fuzzy
-#| msgid "Time Policies"
 msgid "Time to Hire"
-msgstr "Політика часу"
+msgstr "Час до найму"
 
 msgid "Average days from application to hire"
-msgstr ""
+msgstr "Середня кількість днів від заявки до найму"
 
-#, fuzzy
-#| msgid "Invalid selection"
 msgid "In selected period"
-msgstr "Невірний вибір"
+msgstr "У вибраному періоді"
 
-#, fuzzy
-#| msgid "Ongoing Recruitments & Hiring Managers"
 msgid "Ongoing Recruitments & Managers"
-msgstr "Поточні набори та менеджери з найму"
+msgstr "Поточні вакансії та їх менеджери"
 
 msgid "Active hiring with assigned managers"
-msgstr ""
+msgstr "Активний найм із призначеними менеджерами"
 
-#, fuzzy
-#| msgid "Conversion Rate"
 msgid "Source Conversion Rate"
-msgstr "Коефіцієнт конверсії"
+msgstr "Коефіцієнт конверсії джерела"
 
-#, fuzzy
-#| msgid "Create Candidate"
 msgid "Hire rate per candidate source"
-msgstr "Створити кандидата"
+msgstr "Частка найму за джерелом кандидатів"
 
 #| msgid "Interview"
 msgid "Interviews"
 msgstr "Співбесіди"
 
-#, fuzzy
-#| msgid "Open Job Listings"
 msgid "Open positions"
 msgstr "Відкриті вакансії"
 
-#, fuzzy
-#| msgid "View Recruitments"
 msgid "Active recruitments"
-msgstr "Переглянути набори"
+msgstr "Активні вакансії"
 
 msgid "Hired / Total"
-msgstr ""
+msgstr "Найнято / Усього"
 
-#, fuzzy
-#| msgid "Offer Acceptance Rate (OAR)"
 msgid "Acceptance Rate"
-msgstr "Рівень прийняття пропозицій (OAR)"
+msgstr "Рівень прийняття"
 
-#, fuzzy
-#| msgid "Offer letter"
 msgid "Offer accepted"
-msgstr "Лист-пропозиція"
+msgstr "Пропозицію прийнято"
 
-#, fuzzy, python-brace-format
-#| msgid "View candidates"
+#, python-brace-format
 msgid "View ${c.stage} candidates"
-msgstr "Переглянути кандидатів"
+msgstr "Переглянути кандидатів ${c.stage}"
 
 msgid "No source data"
-msgstr ""
+msgstr "Немає даних про джерело"
 
-#, fuzzy
-#| msgid "Choose Open Position"
 msgid "No open positions"
-msgstr "Виберіть відкриту позицію"
+msgstr "Немає відкритих вакансій"
 
 msgid "Filled"
-msgstr ""
+msgstr "Заповнено"
 
-#, fuzzy
-#| msgid "Interviews Scheduled"
 msgid "No interviews scheduled"
-msgstr "Заплановані співбесіди"
+msgstr "Співбесід не запланово"
 
-#, fuzzy
-#| msgid "candidates"
 msgid "No candidates"
-msgstr "кандидати"
+msgstr "Немає кандидатів"
 
-#, fuzzy
-#| msgid "View Recruitments"
 msgid "No active recruitments"
-msgstr "Переглянути набори"
+msgstr "Немає активних вакансій"
 
-#, fuzzy
-#| msgid "Hired Candidates"
 msgid "Hire Rate"
-msgstr "Прийняті кандидати"
+msgstr "Частка найму"
 
-#, fuzzy
-#| msgid "No restricted date available."
 msgid "No hire date data available"
-msgstr "Немає доступних обмежених дат."
+msgstr "Немає даних про дати прийому"
 
-#, fuzzy
-#| msgid " Days"
 msgid "Avg Days"
-msgstr " Днів"
+msgstr "Сер. днів"
 
 msgid "No joinings in this period"
-msgstr ""
+msgstr "У цьому періоді прийомів немає"
 
-#, fuzzy
-#| msgid "Ongoing Recruitments"
 msgid "No ongoing recruitments"
-msgstr "Поточні набори"
+msgstr "Немає активних вакансій"
 
 msgid "Dear"
-msgstr ""
+msgstr "Шановний(-а)"
 
 msgid "Good day!"
 msgstr "Доброго дня!"
 
-#, fuzzy
-#| msgid ""
-#| "I am pleased to inform you that you have been chosen to work with our "
-#| "company,&nbsp;"
 msgid ""
 "I am pleased to inform you that you have been chosen to work with our "
 "company,"
-msgstr "Раді повідомити, що вас обрано для роботи в нашій компанії,&nbsp;"
+msgstr "Раді повідомити, що вас обрано для роботи в нашій компанії,"
 
-#, fuzzy
-#| msgid ". For the position of&nbsp;"
 msgid ". For the position of"
-msgstr ". На посаду&nbsp;"
+msgstr ". На посаду "
 
 msgid ""
 ". As a part of our employee policy, we provide free accommodation to all our"
@@ -22307,11 +19556,8 @@ msgstr ""
 "пропозицію, просимо відповісти на цей лист протягом двох днів після "
 "отримання."
 
-#, fuzzy
-#| msgid ""
-#| "Welcome aboard! We look forward to having you on our team.&nbsp;"
 msgid "Welcome aboard! We look forward to having you on our team."
-msgstr "Ласкаво просимо до команди! Ми раді бачити вас серед нас.&nbsp;"
+msgstr "Вітаємо на борту! Раді бачити вас у нашій команді."
 
 msgid "Regards,"
 msgstr "З повагою,"
@@ -22319,13 +19565,9 @@ msgstr "З повагою,"
 msgid "HR Manager"
 msgstr "Менеджер з персоналу"
 
-#, fuzzy
-#| msgid "Posted on"
 msgid "posted on"
 msgstr "Опубліковано"
 
-#, fuzzy
-#| msgid "LinkedIn Account"
 msgid "LinkedIn account"
 msgstr "Обліковий запис LinkedIn"
 
@@ -22335,10 +19577,8 @@ msgstr "Ви впевнені, що хочете видалити цей наб�
 msgid "Duplicate Recruitment"
 msgstr "Дублювати набір"
 
-#, fuzzy
-#| msgid "Skill Zones"
 msgid "'s Skill Zones"
-msgstr "Зони навичок"
+msgstr " — зони навичок"
 
 msgid "There are currently no skill zone to consider."
 msgstr "Наразі немає зон навичок для розгляду."
@@ -22490,10 +19730,8 @@ msgstr "Набір вже використовується для {}."
 msgid "Note deleted."
 msgstr "Нотатку видалено."
 
-#, fuzzy
-#| msgid "No Attachment found matching the query."
 msgid "No Stage Note found matching the query."
-msgstr "Вкладень, що відповідають запиту, не знайдено."
+msgstr "Нотаток етапу за цим запитом не знайдено."
 
 msgid "You cannot delete this stage while it's in use for {}"
 msgstr "Ви не можете видалити цей етап, доки він використовується для {}"
@@ -22524,23 +19762,19 @@ msgstr "Кандидат %(message)s"
 msgid "{candidate} is {message}"
 msgstr "{candidate} {message}"
 
-#, fuzzy, python-format
-#| msgid "No Document found matching the query."
+#, python-format
 msgid "No %(model_name)s found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "%(model_name)s за цим запитом не знайдено."
 
-#, fuzzy, python-format
-#| msgid "Employees joined in %(year)s"
+#, python-format
 msgid "Hired in %(year)s"
-msgstr "Співробітники, прийняті у %(year)s"
+msgstr "Найнято у %(year)s"
 
 msgid "Openings"
 msgstr "Вакансії"
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No LinkedIn Account found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Акаунтів LinkedIn за цим запитом не знайдено."
 
 msgid "LinkedIn Account activated successfully."
 msgstr "Обліковий запис LinkedIn успішно активовано."
@@ -22557,30 +19791,20 @@ msgstr "З'єднання з LinkedIn успішне."
 msgid "LinkedIn connection failed."
 msgstr "Не вдалося з'єднатися з LinkedIn."
 
-#, fuzzy
-#| msgid "Invalid Recruitment ID"
 msgid "Missing Recruitment ID"
-msgstr "Недійсний ID набору"
+msgstr "Відсутній ID вакансії"
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Recruitment found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Вакансій за цим запитом не знайдено."
 
-#, fuzzy
-#| msgid "Survey Template"
 msgid "Missing Survey Template Title"
-msgstr "Шаблон опитування"
+msgstr "Відсутня назва шаблону опитування"
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Survey Template found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Шаблонів опитувань за цим запитом не знайдено."
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No candidate found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Кандидатів за цим запитом не знайдено."
 
 msgid "File size exceeds the limit. Maximum size is 5 MB"
 msgstr "Розмір файлу перевищує ліміт. Максимальний розмір — 5 МБ"
@@ -22622,36 +19846,26 @@ msgstr "Питання додано"
 msgid "The recruitment entry you are trying to edit does not exist."
 msgstr "Запис набору, який ви намагаєтесь редагувати, не існує."
 
-#, fuzzy
-#| msgid "Recruitment ID is missing"
 msgid "Recruitment ID missing."
-msgstr "Відсутній ID набору"
+msgstr "Відсутній ID вакансії."
 
 msgid "Pipeline cache expired."
-msgstr ""
+msgstr "Кеш воронки прострочений."
 
-#, fuzzy
-#| msgid "Vaccancy is filled"
 msgid "Vacancy is filled"
 msgstr "Вакансію заповнено"
 
 msgid "Vaccancy is filled"
 msgstr "Вакансію заповнено"
 
-#, fuzzy
-#| msgid "No Attachment found matching the query."
 msgid "No Candidate found matching the query."
-msgstr "Вкладень, що відповідають запиту, не знайдено."
+msgstr "Кандидатів за цим запитом не знайдено."
 
-#, fuzzy
-#| msgid "Recruitment closed successfully"
 msgid "Recruitment archived successfully."
-msgstr "Набір успішно завершено"
+msgstr "Вакансію успішно заархівовано."
 
-#, fuzzy
-#| msgid "Recruitment closed successfully"
 msgid "Recruitment un-archived successfully."
-msgstr "Набір успішно завершено"
+msgstr "Вакансію успішно розархівовано."
 
 msgid "Recruitment closed successfully"
 msgstr "Набір успішно завершено"
@@ -22665,10 +19879,8 @@ msgstr "Змін не виявлено."
 msgid "Files uploaded successfully"
 msgstr "Файли успішно завантажено"
 
-#, fuzzy
-#| msgid "No Attachment found matching the query."
 msgid "No Stage Files found matching the query."
-msgstr "Вкладень, що відповідають запиту, не знайдено."
+msgstr "Файлів етапу за цим запитом не знайдено."
 
 msgid "Candidate view status updated"
 msgstr "Статус перегляду кандидата оновлено"
@@ -22679,10 +19891,8 @@ msgstr "Кандидата додано"
 msgid "Job position field is required"
 msgstr "Поле посади є обов’язковим"
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Meeting found matching the query"
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Зустрічей за цим запитом не знайдено"
 
 msgid "Interviewer removed succesfully."
 msgstr "Інтерв'юера успішно видалено."
@@ -22717,15 +19927,11 @@ msgstr "Інтерв'ю успішно оновлено."
 msgid "Mail sent to candidate"
 msgstr "Лист надіслано кандидату"
 
-#, fuzzy
-#| msgid "Sequence"
 msgid "Missing Sequence"
-msgstr "Послідовність"
+msgstr "Відсутня послідовність"
 
-#, fuzzy
-#| msgid "No Attachment found matching the query."
 msgid "No Candidate found matching the query"
-msgstr "Вкладень, що відповідають запиту, не знайдено."
+msgstr "Кандидатів за цим запитом не знайдено"
 
 msgid "Skill Zone created successfully."
 msgstr "Зону навичок успішно створено."
@@ -22754,25 +19960,17 @@ msgstr "Кандидата успішно розархівовано.."
 msgid "Candidate Added to skill zone successfully"
 msgstr "Кандидата успішно додано до зони навичок"
 
-#, fuzzy
-#| msgid "Application Tracking"
 msgid "Application Tracking is enabled "
-msgstr "Відстеження заявки"
+msgstr "Відстеження заявок увімкнено "
 
-#, fuzzy
-#| msgid "Application Tracking"
 msgid "Application Tracking is disabled "
-msgstr "Відстеження заявки"
+msgstr "Відстеження заявок вимкнено "
 
-#, fuzzy
-#| msgid "Rating Visibility"
 msgid "Rating visibility is enabled "
-msgstr "Видимість рейтингу"
+msgstr "Видимість оцінок увімкнено "
 
-#, fuzzy
-#| msgid "Rating Visibility"
 msgid "Rating visibility is disabled "
-msgstr "Видимість рейтингу"
+msgstr "Видимість оцінок вимкнено "
 
 msgid "You have been logged out."
 msgstr "Ви вийшли з системи."
@@ -22780,15 +19978,11 @@ msgstr "Ви вийшли з системи."
 msgid "Reject reason saved"
 msgstr "Причину відхилення збережено"
 
-#, fuzzy
-#| msgid "No Document found matching the query."
 msgid "No Reject Reason found matching the query."
-msgstr "Документів, що відповідають запиту, не знайдено."
+msgstr "Причин відхилення за цим запитом не знайдено."
 
-#, fuzzy
-#| msgid "Last message:"
 msgid "No message"
-msgstr "Останнє повідомлення:"
+msgstr "Немає повідомлень"
 
 msgid "Skill created successfully"
 msgstr "Навички створено успішно"
@@ -22819,20 +20013,14 @@ msgid "Deduction Less than"
 msgstr "Відрахування менше за"
 
 msgid "report_slug, name and config are all required."
-msgstr ""
+msgstr "report_slug, name і config — усі обов'язкові."
 
-#, fuzzy
-#| msgid "Template updated"
 msgid "Template saved."
-msgstr "Шаблон оновлено"
+msgstr "Шаблон збережено."
 
-#, fuzzy
-#| msgid "Employee not found."
 msgid "Template not found."
-msgstr "Співробітника не знайдено."
+msgstr "Шаблон не знайдено."
 
-#, fuzzy
-#| msgid "Template deleted"
 msgid "Template deleted."
 msgstr "Шаблон видалено"
 
@@ -22842,10 +20030,8 @@ msgstr "Сторінку не знайдено!"
 msgid "Oops! The page you are looking for could not be found."
 msgstr "Отакої! Сторінку, яку ви шукаєте, не знайдено."
 
-#, fuzzy
-#| msgid "Return Condition Images"
 msgid "Return to the main page"
-msgstr "Зображення стану при поверненні"
+msgstr "Повернутися на головну"
 
 msgid "Method Not Allowed!"
 msgstr "Метод не дозволено!"
@@ -22868,112 +20054,74 @@ msgstr "Топ-10 відділів"
 msgid "Daily leaves — current week"
 msgstr "Щоденні відпустки — поточний тиждень"
 
-#, fuzzy
-#| msgid "Employee tag"
 msgid "Employee Status"
-msgstr "Тег співробітника"
+msgstr "Статус співробітника"
 
-#, fuzzy
-#| msgid "Activate"
 msgid "Active vs Inactive"
-msgstr "Активувати"
+msgstr "Активні та неактивні"
 
-#, fuzzy
-#| msgid "Active Employees"
 msgid "Active employees"
 msgstr "Активні працівники"
 
-#, fuzzy
-#| msgid "End Date Breakdown"
 msgid "Leave Breakdown"
-msgstr "Розбивка кінцевої дати"
+msgstr "Розбивка відпусток"
 
-#, fuzzy
-#| msgid "Department Overtime Chart"
 msgid "Department Overtime"
-msgstr "Діаграма понаднормових по відділах"
+msgstr "Понаднормові за відділами"
 
-#, fuzzy
-#| msgid "Overtime Hours"
 msgid "Overtime hours distribution"
-msgstr "Понаднормові години"
+msgstr "Розподіл понаднормових годин"
 
 msgid "Weekly rate — last 12 weeks"
-msgstr ""
+msgstr "Щотижнева ставка — останні 12 тижнів"
 
-#, fuzzy
-#| msgid "Candidate stage updated"
 msgid "Candidates by stage per recruitment"
-msgstr "Етап кандидата оновлено"
+msgstr "Кандидати за етапами по вакансіях"
 
-#, fuzzy
-#| msgid "Current Hiring Pipeline"
 msgid "Hiring Timeline"
-msgstr "Поточна воронка найму"
+msgstr "Хронологія найму"
 
-#, fuzzy
-#| msgid "Employees joined in %(year)s"
 msgid "Employees joined by month"
-msgstr "Співробітники, прийняті у %(year)s"
+msgstr "Прийняті співробітники за місяцями"
 
-#, fuzzy
-#| msgid "Department Leaves"
 msgid "Department-wise leave requests"
-msgstr "Відпустки відділу"
+msgstr "Заявки на відпустку за відділами"
 
-#, fuzzy
-#| msgid "Department Leaves"
 msgid "Department Leave Days"
-msgstr "Відпустки відділу"
+msgstr "Дні відпусток за відділами"
 
-#, fuzzy
-#| msgid "Total Leave Days Days"
 msgid "Total leave days by department"
-msgstr "Загальна кількість днів відпустки"
+msgstr "Усього днів відпустки за відділами"
 
-#, fuzzy
-#| msgid "Recruitment Survey"
 msgid "Recruitment Funnel"
-msgstr "Опитування для найму"
+msgstr "Воронка підбору"
 
 msgid "Candidates by stage — active recruitments"
-msgstr ""
+msgstr "Кандидати за етапами — активні вакансії"
 
-#, fuzzy
-#| msgid "Employee Type"
 msgid "Employee Turnover"
-msgstr "Тип співробітника"
+msgstr "Плинність кадрів"
 
 msgid "New hires vs exits — last 6 months"
-msgstr ""
+msgstr "Прийоми та звільнення — останні 6 місяців"
 
-#, fuzzy
-#| msgid "Payroll"
 msgid "Payroll Summary"
-msgstr "Заробітна плата"
+msgstr "Зведення зарплати"
 
 msgid "Current vs previous month"
-msgstr ""
+msgstr "Поточний та попередній місяць"
 
-#, fuzzy
-#| msgid "Announcement"
 msgid "New Announcement"
-msgstr "Оголошення"
+msgstr "Нове оголошення"
 
-#, fuzzy
-#| msgid "Waiting Approval"
 msgid "Pending Approvals"
-msgstr "Очікує затвердження"
+msgstr "Очікують затвердження"
 
-#, fuzzy
-#| msgid "Attendance overtime approve"
 msgid "Attendance & Overtime"
-msgstr "Погодження понаднормових"
+msgstr "Відвідуваність і понаднормові"
 
-#, fuzzy
-#| msgid "Weekly Leave Analytics"
 msgid "Leave Analytics"
-msgstr "Тижнева аналітика відпусток"
+msgstr "Аналітика відпусток"
 
 msgid "this month"
 msgstr "Цього місяця"
@@ -22981,70 +20129,50 @@ msgstr "Цього місяця"
 msgid "No new joiners"
 msgstr "Немає нових співробітників"
 
-#, fuzzy
-#| msgid "Pending"
 msgid "No pending"
-msgstr "Очікується"
+msgstr "Немає в очікуванні"
 
 msgid "Open Recruitments"
 msgstr "Відкриті рекрутингові процеси"
 
-#, fuzzy
-#| msgid "Expired"
 msgid "Expires"
-msgstr "Прострочено"
+msgstr "Спливає"
 
-#, fuzzy
-#| msgid "Leave days"
 msgid "My Leave Today"
-msgstr "Дні відпустки"
+msgstr "Моя відпустка сьогодні"
 
-#, fuzzy
-#| msgid "You are not allowed to answer"
 msgid "You are not on leave today"
-msgstr "Вам не дозволено відповідати"
+msgstr "Сьогодні ви не у відпустці"
 
-#, fuzzy
-#| msgid "Weekly"
 msgid "Weekly rate"
-msgstr "Щотижня"
+msgstr "Щотижнева ставка"
 
 msgid "No holidays in the next 7 days"
-msgstr ""
+msgstr "Найближчі 7 днів свят немає"
 
 msgid "No holidays this week"
-msgstr ""
+msgstr "Цього тижня немає свят"
 
-#, fuzzy
-#| msgid "View Recruitments"
 msgid "active recruitments"
-msgstr "Переглянути набори"
+msgstr "активні вакансії"
 
-#, fuzzy
-#| msgid "Hired"
 msgid "hired"
 msgstr "Прийнято на роботу"
 
-#, fuzzy
-#| msgid "Switch to Closed Recruitments"
 msgid "Failed to load recruitment data"
-msgstr "Перейти до закритих наборів"
+msgstr "Не вдалося завантажити дані вакансії"
 
 msgid "6-month turnover rate"
-msgstr ""
+msgstr "Плинність за 6 місяців"
 
 msgid "Exits"
-msgstr ""
+msgstr "Звільнення"
 
-#, fuzzy
-#| msgid "Returned date"
 msgid "No turnover data"
-msgstr "Дата повернення"
+msgstr "Немає даних про плинність"
 
-#, fuzzy
-#| msgid "Reset Month"
 msgid "Prev Month"
-msgstr "Місяць скидання"
+msgstr "Попередній місяць"
 
 msgid "Select All Rows"
 msgstr "Вибрати всі рядки"
@@ -23059,12 +20187,10 @@ msgid "You dont have permission to the feature"
 msgstr "У вас немає дозволу на цю функцію"
 
 msgid "Setting Up Your Workspace"
-msgstr ""
+msgstr "Налаштування вашого робочого простору"
 
-#, fuzzy
-#| msgid "Loading Demo Database"
 msgid "Loading demo database, please wait…"
-msgstr "Завантаження демонстраційної бази даних"
+msgstr "Завантаження демо-бази, зачекайте…"
 
 msgid "Database Authentication"
 msgstr "Автентифікація бази даних"
@@ -23100,7 +20226,7 @@ msgid "Clear all"
 msgstr "Очистити все"
 
 msgid "Horilla HRMS"
-msgstr ""
+msgstr "Horilla HRMS"
 
 msgid "Sign Up"
 msgstr "Реєстрація"
@@ -23119,16 +20245,16 @@ msgid "Please sign up to access the Horilla HRMS."
 msgstr "Будь ласка, зареєструйтеся для доступу до Horilla HRMS."
 
 msgid "e.g. Adam"
-msgstr ""
+msgstr "напр. Адам"
 
 msgid "e.g. Luis"
-msgstr ""
+msgstr "напр. Луїс"
 
 msgid "e.g. 9865324512"
-msgstr ""
+msgstr "напр. 9865324512"
 
 msgid "e.g. PEP001"
-msgstr ""
+msgstr "напр. PEP001"
 
 msgid "Use alphanumeric characters"
 msgstr "Використовуйте літери та цифри"
@@ -23140,16 +20266,16 @@ msgid "Secure Sign-in"
 msgstr "Безпечний вхід"
 
 msgid "Jan 03, 2023, at 11:13AM"
-msgstr ""
+msgstr "03 січ. 2023, 11:13"
 
 msgid "Jan 01, 2023, at 05:13PM"
-msgstr ""
+msgstr "01 січ. 2023, 17:13"
 
 msgid "Dec 31, 2022, at 02:00PM"
-msgstr ""
+msgstr "31 груд. 2022, 14:00"
 
 msgid "Dec 31, 2022, at 10:27AM"
-msgstr ""
+msgstr "31 груд. 2022, 10:27"
 
 msgid "View all comments"
 msgstr "Переглянути всі коментарі"
@@ -23220,15 +20346,11 @@ msgstr "Точка перерви відвідуваності"
 msgid "Geo & Face Config"
 msgstr "Налаштування геолокації та розпізнавання обличчя"
 
-#, fuzzy
-#| msgid "Configuration"
 msgid "Whatsapp Configuration"
-msgstr "Конфігурація"
+msgstr "Налаштування WhatsApp"
 
-#, fuzzy
-#| msgid "Enter Credentials"
 msgid "Whatsapp Credentials"
-msgstr "Введіть облікові дані"
+msgstr "Облікові дані WhatsApp"
 
 msgid "Invalid File"
 msgstr "Недійсний файл"
@@ -23286,9 +20408,9 @@ msgstr "Установити пароль"
 
 msgid "Please correct the error below."
 msgid_plural "Please correct the errors below."
-msgstr[0] "Будь ласка, виправте помилку нижче."
-msgstr[1] "Будь ласка, виправте помилки нижче."
-msgstr[2] "Будь ласка, виправте помилки нижче."
+msgstr[0] "Виправте помилку нижче."
+msgstr[1] "Виправте помилки нижче."
+msgstr[2] "Виправте помилки нижче."
 
 #, python-format
 msgid "Enter a new password for the user <strong>%(username)s</strong>."
@@ -23563,108 +20685,72 @@ msgstr "Видалити вибраний об’єкт %(model)s"
 msgid "View selected %(model)s"
 msgstr "Переглянути вибраний об’єкт %(model)s"
 
-#, fuzzy
-#| msgid "Meta Phone Number"
 msgid "Phone Number"
-msgstr "Мета номер телефону"
+msgstr "Номер телефону"
 
-#, fuzzy
-#| msgid "Meta Phone Number ID"
 msgid "Phone Number ID"
-msgstr "Ідентифікатор метателефонного номера"
+msgstr "ID номера телефону"
 
-#, fuzzy
-#| msgid "Meta Business ID"
 msgid "Bussiness ID"
-msgstr "Мета бізнес-ідентифікатор"
+msgstr "Ідентифікатор бізнесу"
 
-#, fuzzy
-#| msgid "API Token"
 msgid "Token"
-msgstr "API-токен"
+msgstr "Токен"
 
-#, fuzzy
-#| msgid "Are you sure you want to delete this schedule?"
 msgid "Are you sure you want to delete this credential?"
-msgstr "Ви впевнені, що хочете видалити цей графік?"
+msgstr "Ви впевнені, що хочете видалити ці облікові дані?"
 
-#, fuzzy
-#| msgid "Send Message"
 msgid "Send Test Message"
-msgstr "Надіслати повідомлення"
+msgstr "Надіслати тестове повідомлення"
 
-#, fuzzy
-#| msgid "Created at"
 msgid "Create whatsapp"
-msgstr "Створено"
+msgstr "Створити WhatsApp"
 
-#, fuzzy
-#| msgid "Enter Credentials"
 msgid "Update Credentials"
-msgstr "Введіть облікові дані"
+msgstr "Оновити облікові дані"
 
-#, fuzzy
-#| msgid "Grace time updated successfully."
 msgid "Crediential updated successfully"
-msgstr "Пільговий час успішно оновлено."
+msgstr "Облікові дані успішно оновлено"
 
-#, fuzzy
-#| msgid "Meeting created successfully"
 msgid "Crediential created successfully"
-msgstr "Зустріч успішно створена"
+msgstr "Облікові дані успішно створено"
 
 msgid "Crediential deleted."
 msgstr "Облікові дані видалено."
 
-#, fuzzy
-#| msgid "Mail sent successfully"
 msgid "Message sent successfully"
-msgstr "Лист успішно надіслано"
+msgstr "Повідомлення успішно надіслано"
 
-#, fuzzy
-#| msgid "Stage not found"
 msgid "message not send"
-msgstr "Етап не знайдено"
+msgstr "повідомлення не надіслано"
 
 msgid "This token is used to connect webhook to the server"
-msgstr ""
+msgstr "Цей токен використовується для підключення вебхука до сервера"
 
-#, fuzzy
-#| msgid "Activate WhatsApp Business API integration"
 msgid "Whatsapp Integration"
-msgstr "Активуйте інтеграцію WhatsApp Business API"
+msgstr "Інтеграція WhatsApp"
 
-#, fuzzy
-#| msgid "Enable WhatsApp"
 msgid "Enable Whatsapp"
 msgstr "Увімкніть WhatsApp"
 
 msgid "Enable this to integrate Whatsapp to Horilla."
-msgstr ""
+msgstr "Увімкніть, щоб інтегрувати WhatsApp у Horilla."
 
 msgid ""
 "Send HR notifications and updates directly through WhatsApp for better "
 "visibility."
 msgstr ""
+"Надсилайте HR-сповіщення й оновлення прямо через WhatsApp для кращої "
+"видимості."
 
-#, fuzzy
-#| msgid "Create Survey Template"
 msgid "Create Message Template and Flows"
-msgstr "Створити шаблон опитування"
+msgstr "Створити шаблон повідомлення та флоу"
 
-#, fuzzy
-#| msgid ""
-#| " Do you really want to allow this employee to access and log into this "
-#| "webpage?"
 msgid "Do you want to create Templates and Flows in whatsapp manager?"
-msgstr ""
-" Ви дійсно хочете дозволити цьому співробітнику доступ і вхід на цю веб-"
-"сторінку?"
+msgstr "Ви бажаєте створити шаблони та флоу в менеджері WhatsApp?"
 
-#, fuzzy
-#| msgid "Meta Phone Number"
 msgid "Phone number"
-msgstr "Мета номер телефону"
+msgstr "Номер телефону"
 
 msgid "Message templates and flows created successfully."
 msgstr "Шаблони повідомлень і потоки успішно створено."

--- a/horilla/locale/uk/LC_MESSAGES/django.po
+++ b/horilla/locale/uk/LC_MESSAGES/django.po
@@ -20962,6 +20962,20 @@ msgstr "Оновити щотижневі вихідні"
 msgid "Weekly Off Day"
 msgstr "Щотижневий вихідний"
 
+#: horilla_theme/templates/recruitment/open_recruitments.html
+msgctxt "job application"
+msgid "Apply"
+msgstr "Подати заявку"
+
+#: horilla_theme/templates/candidate/application_form.html
+msgctxt "person"
+msgid "Name"
+msgstr "Ім'я"
+
+#: horilla_theme/templates/recruitment/open_recruitments.html
+msgid "%(applied)s applied of %(capacity)s capacity"
+msgstr "Заявок: %(applied)s з %(capacity)s"
+
 #~ msgid "Current User"
 #~ msgstr "Поточний користувач"
 

--- a/horilla/locale/uk/LC_MESSAGES/djangojs.po
+++ b/horilla/locale/uk/LC_MESSAGES/djangojs.po
@@ -417,3 +417,11 @@ msgstr "Використовується для відмітки присутн�
 
 msgid "Your current company access"
 msgstr "Ваш поточний доступ до компанії"
+
+#: static/index/country.js
+msgid "Select Country"
+msgstr "Виберіть країну"
+
+#: static/index/country.js
+msgid "Select State"
+msgstr "Виберіть область"

--- a/horilla/locale/uk/LC_MESSAGES/djangojs.po
+++ b/horilla/locale/uk/LC_MESSAGES/djangojs.po
@@ -2,203 +2,203 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: Horilla\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2025-12-18 13:57+0530\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"PO-Revision-Date: 2026-08-14 12:00+0300\n"
+"Last-Translator: SCG\n"
+"Language-Team: Ukrainian\n"
 "Language: uk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
 
 msgid "An unexpected error occurred. Please refresh the page."
-msgstr ""
+msgstr "Сталася неочікувана помилка. Оновіть сторінку."
 
 msgid "Do you really want to validate all the selected attendances?"
-msgstr ""
+msgstr "Ви справді хочете перевірити всі вибрані відвідування?"
 
 msgid "No rows are selected from Validate Attendances."
-msgstr ""
+msgstr "Не вибрано жодного рядка з «Перевірити відвідуваність»."
 
 msgid "Do you really want to approve OT for all the selected attendances?"
 msgstr ""
+"Ви справді хочете затвердити понаднормові для всіх вибраних відвідувань?"
 
 msgid "No rows are selected from OT Attendances."
-msgstr ""
+msgstr "Не вибрано жодного рядка з понаднормових відвідувань."
 
 msgid "Do you really want to reject all the selected attendance requests?"
-msgstr ""
+msgstr "Ви справді хочете відхилити всі вибрані заявки на відвідування?"
 
 msgid "Pending Attendance Update Request!"
-msgstr ""
+msgstr "Заявка на оновлення відвідування в очікуванні!"
 
 msgid ""
 "An attendance request exists for updating this attendance prior to "
 "validation."
-msgstr ""
+msgstr "Існує заявка на оновлення цього відвідування до його перевірки."
 
 msgid "View Request"
-msgstr ""
+msgstr "Переглянути заявку"
 
 msgid "Some selected requests have already been approved."
-msgstr ""
+msgstr "Деякі вибрані заявки вже затверджено."
 
 msgid "Some selected requests have already been rejected."
-msgstr ""
+msgstr "Деякі вибрані заявки вже відхилено."
 
 msgid "Do you wish to create a Leave Report?"
-msgstr ""
+msgstr "Бажаєте створити звіт по відпустках?"
 
 msgid "Do you want to reject the selected leave requests?"
-msgstr ""
+msgstr "Бажаєте відхилити вибрані заявки на відпустку?"
 
 msgid "Do you want to send the payslip by mail?"
-msgstr ""
+msgstr "Бажаєте надіслати розрахунковий листок поштою?"
 
 msgid "Name of Employees"
-msgstr ""
+msgstr "Імена співробітників"
 
 msgid "Amount"
-msgstr ""
+msgstr "Сума"
 
 msgid "Upload Completed!"
-msgstr ""
+msgstr "Завантаження завершено!"
 
 msgid "Imported Successfully!"
-msgstr ""
+msgstr "Успішно імпортовано!"
 
 msgid "Please upload a file with the .xlsx extension only."
-msgstr ""
+msgstr "Завантажуйте лише файли з розширенням .xlsx."
 
 msgid "visible"
-msgstr ""
+msgstr "visible"
 
 msgid "bgcolor"
-msgstr ""
+msgstr "bgcolor"
 
 msgid "bordercolor"
-msgstr ""
+msgstr "bordercolor"
 
 msgid "borderwidth"
-msgstr ""
+msgstr "borderwidth"
 
 msgid "thickness"
-msgstr ""
+msgstr "thickness"
 
 msgid "autorange"
-msgstr ""
+msgstr "autorange"
 
 msgid "range"
-msgstr ""
+msgstr "range"
 
 msgid "x"
-msgstr ""
+msgstr "x"
 
 msgid "y"
-msgstr ""
+msgstr "y"
 
 msgid "minor"
-msgstr ""
+msgstr "minor"
 
 msgid "label"
-msgstr ""
+msgstr "label"
 
 msgid "arrowlen"
-msgstr ""
+msgstr "arrowlen"
 
 msgid "source"
-msgstr ""
+msgstr "source"
 
 msgid "target"
-msgstr ""
+msgstr "target"
 
 msgid "value"
-msgstr ""
+msgstr "value"
 
 msgid "line.color"
-msgstr ""
+msgstr "line.color"
 
 msgid "line.width"
-msgstr ""
+msgstr "line.width"
 
 msgid "hoverinfo"
-msgstr ""
+msgstr "hoverinfo"
 
 msgid "hovertemplate"
-msgstr ""
+msgstr "hovertemplate"
 
 msgid "color"
-msgstr ""
+msgstr "color"
 
 msgid "hovercolor"
-msgstr ""
+msgstr "hovercolor"
 
 msgid "customdata"
-msgstr ""
+msgstr "customdata"
 
 msgid "punc"
-msgstr ""
+msgstr "punc"
 
 msgid "name"
-msgstr ""
+msgstr "name"
 
 msgid "keyword"
-msgstr ""
+msgstr "keyword"
 
 msgid "arrow"
-msgstr ""
+msgstr "arrow"
 
 msgid "operator"
-msgstr ""
+msgstr "operator"
 
 msgid "close"
-msgstr ""
+msgstr "close"
 
 msgid "Confirm"
-msgstr ""
+msgstr "Підтвердити"
 
 msgid "Close"
-msgstr ""
+msgstr "Закрити"
 
 msgid "Cancel"
-msgstr ""
+msgstr "Скасувати"
 
 msgid "Selected"
-msgstr ""
+msgstr "Вибрано"
 
 msgid "Uploading..."
-msgstr ""
+msgstr "Завантаження..."
 
 msgid "No Records found"
-msgstr ""
+msgstr "Записів не знайдено"
 
 msgid "Do you want to download the excel file?"
-msgstr ""
+msgstr "Бажаєте завантажити файл Excel?"
 
 msgid "Do you want to download the template?"
-msgstr ""
+msgstr "Бажаєте завантажити шаблон?"
 
 msgid "No rows are selected from the records."
-msgstr ""
+msgstr "Не вибрано жодного рядка із записів."
 
 msgid "Do you really want to delete all the selected records?"
-msgstr ""
+msgstr "Ви справді хочете видалити всі вибрані записи?"
 
 msgid "Do you really want to archive all the selected records?"
-msgstr ""
+msgstr "Ви справді хочете заархівувати всі вибрані записи?"
 
 msgid "Do you really want to approve all the selected requests?"
-msgstr ""
+msgstr "Ви справді хочете затвердити всі вибрані заявки?"
 
 msgid "Do you really want to unarchive all the selected records?"
-msgstr ""
+msgstr "Ви справді хочете розархівувати всі вибрані записи?"
 
 msgid "Ok"
 msgstr "добре"
@@ -206,8 +206,10 @@ msgstr "добре"
 msgid "Total vacancy is %(vacancy)s."
 msgstr "Загальна кількість вакансій %(vacancy)s."
 
-msgid "Are you sure to change the candidate from %(from)s stage to %(to)s stage"
-msgstr "Ви впевнені, що змінюєте кандидата зі стадії %(from)s на стадію %(to)s"
+msgid ""
+"Are you sure to change the candidate from %(from)s stage to %(to)s stage"
+msgstr ""
+"Ви впевнені, що змінюєте кандидата зі стадії %(from)s на стадію %(to)s"
 
 msgid "Stage updated"
 msgstr "Етап оновлено"
@@ -215,8 +217,11 @@ msgstr "Етап оновлено"
 msgid "Confirm Stage Change"
 msgstr "Підтвердьте зміну етапу"
 
-msgid "The candidate is being moved from %(from)s to the %(to)s stage. Do you want to proceed?"
-msgstr "Кандидат переміщується з %(from)s на етап %(to)s. Ви бажаєте продовжити?"
+msgid ""
+"The candidate is being moved from %(from)s to the %(to)s stage. Do you want "
+"to proceed?"
+msgstr ""
+"Кандидат переміщується з %(from)s на етап %(to)s. Ви бажаєте продовжити?"
 
 msgid "Don't show this again in this session"
 msgstr "Не показувати це знову в цьому сеансі"
@@ -229,127 +234,186 @@ msgstr "Цей рух заборонено."
 
 msgid "Do you really want to delete all the selected attendances?"
 msgstr "Ви дійсно хочете видалити всі вибрані відвідування?"
+
 msgid "Do you really want to delete this employee?"
 msgstr "Ви справді хочете видалити цього співробітника?"
+
 msgid "No rows are selected for deleting attendances."
 msgstr "Не вибрано жодного рядка для видалення явок."
 
-
 msgid "Add Stage"
 msgstr "Додати етап"
+
 msgid "Add announcement"
 msgstr "Додати оголошення"
+
 msgid "Add candidate"
 msgstr "Додати кандидата"
+
 msgid "Add candidate to stage option"
 msgstr "Опція додавання кандидата до етапу"
+
 msgid "Add new recruitment"
 msgstr "Додати нову вакансію"
+
 msgid "Add new stage to recruitment"
 msgstr "Додати новий етап до найму"
+
 msgid "All your company and base configurations"
 msgstr "Усі налаштування компанії та базові конфігурації"
+
 msgid "App"
 msgstr "Додаток"
+
 msgid "Approve or Reject Options"
 msgstr "Опції схвалити або відхилити"
+
 msgid "Candidate"
 msgstr "Кандидат"
+
 msgid "Candidate change stage option"
 msgstr "Опція зміни етапу кандидата"
+
 msgid "Candidate management options"
 msgstr "Параметри керування кандидатами"
+
 msgid "Candidate rating option"
 msgstr "Опція оцінки кандидата"
+
 msgid "Candidate record"
 msgstr "Запис кандидата"
+
 msgid "Change Stage"
 msgstr "Змінити етап"
+
 msgid "Company"
 msgstr "Компанія"
+
 msgid "Create Quick Requests"
 msgstr "Створити швидкі запити"
+
 msgid "Create announcement from dashboard"
 msgstr "Створити оголошення з панелі"
+
 msgid "Dashboard"
 msgstr "Панель"
+
 msgid "Dashboard Actions"
 msgstr "Дії панелі"
+
 msgid "Dashboard Tiles"
 msgstr "Плитки панелі"
+
 msgid "Filter"
 msgstr "Фільтр"
+
 msgid "Filter Tag"
 msgstr "Мітка фільтра"
+
 msgid "Filter tag option"
 msgstr "Опція мітки фільтра"
+
 msgid "Horilla Dashboard Tiles"
 msgstr "Плитки панелі Horilla"
+
 msgid "Horilla Hr Apps. eg Dashboard"
 msgstr "Додатки Horilla HR, напр. Панель"
+
 msgid "Horilla dashboard section"
 msgstr "Розділ панелі Horilla"
+
 msgid "Language"
 msgstr "Мова"
+
 msgid "Mark Attendance"
 msgstr "Відмітити присутність"
+
 msgid "Multi-Company"
 msgstr "Кілька компаній"
+
 msgid "Multi-Company options"
 msgstr "Параметри кількох компаній"
+
 msgid "Multi-Language options"
 msgstr "Багатомовні параметри"
+
 msgid "New Recruitment"
 msgstr "Новий найм"
+
 msgid "Notification"
 msgstr "Сповіщення"
+
 msgid "Notifications section"
 msgstr "Розділ сповіщень"
+
 msgid "Options"
 msgstr "Параметри"
+
 msgid "Pipeline"
 msgstr "Воронка"
+
 msgid "Pipeline filter option"
 msgstr "Опція фільтра воронки"
+
 msgid "Profile"
 msgstr "Профіль"
+
 msgid "Profile and change password options"
 msgstr "Параметри профілю та зміни пароля"
+
 msgid "Quick Actions"
 msgstr "Швидкі дії"
+
 msgid "Quick Filters"
 msgstr "Швидкі фільтри"
+
 msgid "Rating"
 msgstr "Оцінка"
+
 msgid "Recruitment"
 msgstr "Найм"
+
 msgid "Recruitment pipeline management"
 msgstr "Керування воронкою найму"
+
 msgid "Recruitment stage"
 msgstr "Етап найму"
+
 msgid "Search"
 msgstr "Пошук"
+
 msgid "Search in candidate, recruitment and stage"
 msgstr "Пошук за кандидатом, наймом і етапом"
+
 msgid "Selected settings view"
 msgstr "Вибраний вигляд налаштувань"
+
 msgid "Settings"
 msgstr "Налаштування"
+
 msgid "Settings Options"
 msgstr "Параметри налаштувань"
+
 msgid "Settings View"
 msgstr "Вигляд налаштувань"
+
 msgid "Settings configurations"
 msgstr "Конфігурації налаштувань"
+
 msgid "Settings menu bar"
 msgstr "Панель меню налаштувань"
+
 msgid "Stage"
 msgstr "Етап"
+
 msgid "Toggle View"
 msgstr "Перемкнути вигляд"
+
 msgid "Toggle view type"
 msgstr "Перемкнути тип вигляду"
+
 msgid "Used to mark your attendance"
 msgstr "Використовується для відмітки присутності"
+
 msgid "Your current company access"
 msgstr "Ваш поточний доступ до компанії"

--- a/horilla_theme/templates/candidate/application_form.html
+++ b/horilla_theme/templates/candidate/application_form.html
@@ -84,7 +84,7 @@
                             <div class= "lg:h-[calc(100vh_-_160px)] overflow-hidden overflow-y-auto">
                                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4 ">
                                     <div>
-                                        <label class="required-star" for="name">{% trans "Name" %}</label>
+                                        <label class="required-star" for="name">{% trans "Name" context "person" %}</label>
                                         <div class="relative">
                                             <input type="text" id="name" name="name" placeholder="{% trans 'Enter your name' %}" required style="padding-left: 35px;" value="{{ form.name.value|default:'' }}">
                                             <span class="absolute left-1 top-0 bottom-0 m-auto flex items-center ps-2 text-sm text-[{{theme_obj.primary_700}}]">
@@ -279,6 +279,9 @@
     </div>
 
 
+    {# country.js localises its option labels via gettext(); this page is standalone
+       and does not extend index.html, so the catalog has to be pulled in here #}
+    <script src="{% url 'javascript-catalog' %}"></script>
     <script src="{% static '/index/country.js' %}"></script>
     <script>
         {% include 'select2.js' %}

--- a/horilla_theme/templates/recruitment/open_recruitments.html
+++ b/horilla_theme/templates/recruitment/open_recruitments.html
@@ -199,11 +199,11 @@
                                         </div>
                                     </div>
                                     <div class="text-xs text-dark-200 font-medium">
-                                        {{ recruitment.candidate.all|length }}
-                                        {% trans "Applied" %}
-                                        {% trans "of" %}
-                                        {{ recruitment.vacancy }}
-                                        {% trans "Capacity" %}
+                                        {% comment %}
+                                        One phrase rather than three separate words, so a
+                                        translation can order and inflect it naturally.
+                                        {% endcomment %}
+                                        {% blocktrans with applied=recruitment.candidate.all|length capacity=recruitment.vacancy %}{{ applied }} applied of {{ capacity }} capacity{% endblocktrans %}
                                     </div>
                                 </div>
                             {% else %}
@@ -230,7 +230,8 @@
                                         target="_blank"
                                         class="w-20 justify-center px-4 py-2 bg-brand-600 text-white rounded-md text-xs flex items-center gap-2 hover:bg-brand-800 transition duration-300"
                                     >
-                                        {% trans "Apply" %}
+                                        {# context: this is "apply for a job", not "apply a filter" #}
+                                        {% trans "Apply" context "job application" %}
                                         <i class="fa-solid fa-arrow-right transform -rotate-45"></i>
                                     </a>
                                 </div>

--- a/static/index/country.js
+++ b/static/index/country.js
@@ -686,6 +686,13 @@ s_a[251] =
 s_a[252] =
     "Bulawayo|Harare|ManicalandMashonaland Central|Mashonaland East|Mashonaland West|Masvingo|Matabeleland North|Matabeleland South|Midlands";
 
+// Option labels below are user-facing. gettext() comes from Django's JS catalog,
+// which some standalone pages (e.g. the public application form) do not load —
+// fall back to English there instead of throwing a ReferenceError.
+function countryI18n(text) {
+    return typeof gettext === "function" ? gettext(text) : text;
+}
+
 function populateStates(countryElementId, stateElementId) {
     var countryEl = document.getElementById(countryElementId);
     var stateEl = document.getElementById(stateElementId);
@@ -695,7 +702,7 @@ function populateStates(countryElementId, stateElementId) {
     var selectedState = stateEl.getAttribute('data-selected') || '';
 
     stateEl.length = 0;
-    stateEl.options[0] = new Option("Select State", "");
+    stateEl.options[0] = new Option(countryI18n("Select State"), "");
     stateEl.selectedIndex = 0;
 
     if (s_a[selectedCountryIndex]) {
@@ -720,7 +727,7 @@ function populateCountries(countryElementId, stateElementId) {
 
     var selectedCountry = countryEl.getAttribute('data-selected') || '';
     countryEl.length = 0;
-    countryEl.options[0] = new Option("Select Country", "");
+    countryEl.options[0] = new Option(countryI18n("Select Country"), "");
 
     for (var i = 0; i < country_arr.length; i++) {
         let country = country_arr[i].replace(/'/g, '`');


### PR DESCRIPTION
## Problem

`horilla/locale/uk/LC_MESSAGES/django.po` ships **1564 fuzzy entries**. `msgfmt` drops fuzzy translations, so the compiled catalog held only **4578 of 6596** strings — effective coverage was **69%**, not the 92% the `.po` suggests, and roughly 2000 strings rendered in English for Ukrainian users. `djangojs.po` was at 71/131.

The fuzzy set was not merely stale. `msgmerge` had matched many translations onto a *different* string, so enabling `--use-fuzzy` would have shipped visibly wrong labels:

| msgid | fuzzy translation actually meant |
|---|---|
| `version` | Permissions |
| `Department Performance` | Department Leaves |
| `Today — by department` | Name of the department |
| `No portal data` | Export Data |
| `Added Employee` | Add Employee |

So every entry was reviewed and retranslated rather than un-fuzzied.

## What this PR does

**1. Completes the catalogs**

- `django.po`: **6596/6596** translated, **0 fuzzy**
- `djangojs.po`: **131/131** translated, header filled in
- the 12 plural entries now carry all three Ukrainian forms instead of a single `msgstr`, which gettext ignores for plurals

Deliberately left untranslated, because they are identifiers rather than UI text and translating them breaks the feature:

- Ionicons names — `add sharp`, `checkmark`, `chevron down outline`, …
- Plotly.js property names in `djangojs` — `bgcolor`, `hovertemplate`, `line.width`, `customdata`, … and code-editor token types (`punc`, `keyword`, `operator`)
- JS template literals — `${b.name}`, `${emp.name}`, `${c.stage}`

**2. Fixes three strings that no translation could get right**

- **`Apply`** is one msgid shared by the job-card button on the public career page and the Apply button of eight attendance filter forms. One translation cannot serve both, so the job button read "apply a filter" in Ukrainian. The card now uses `context "job application"`.
- **`Name`** on the application form is a person's name, but the same msgid labels object names elsewhere (leave types, filters), so it read "Назва" (title/designation). The form now uses `context "person"`.
- **The job-card counter** was three separate words — `{{ n }} {% trans "Applied" %} {% trans "of" %} {{ n }} {% trans "Capacity" %}` — which cannot be ordered or inflected in Ukrainian (it read "3 Подано заявку з 1 Місткість"). It is now one `blocktrans` phrase and reads "Заявок: 3 з 1".

**3. Localises the country/state selects on the public application form**

`country.js` hard-coded `new Option("Select Country", "")`, so those labels were always English and never appeared in any catalog. They now go through `gettext()`, guarded so pages without a JS catalog fall back to English rather than throwing `ReferenceError`:

```js
function countryI18n(text) {
    return typeof gettext === "function" ? gettext(text) : text;
}
```

The public application form is a standalone page that never loaded Django's JS catalog, so it now pulls in `{% url 'javascript-catalog' %}` (the view is public — verified anonymously).

## Verification

Deployed to a production instance and checked live: the counter renders "Заявок: 3 з 1", the button "Подати заявку", the form label "Ім'я", and `/jsi18n/` with `Accept-Language: uk` serves "Виберіть країну" / "Виберіть область". `msgfmt --check` passes on both catalogs; the compiled `django.mo` went from 4578 to 6596 entries.
