### PR TITLE
fix(onboarding): "Start Onboarding" never starts onboarding

### DIFF
--- a/onboarding/views.py
+++ b/onboarding/views.py
@@ -535,15 +535,20 @@ def candidates_single_view(request, id, **kwargs):
                 _("%(recruitment)s has no stage..")
                 % {"recruitment": candidate.recruitment_id},
             )
+        # OnboardingTask lost its own recruitment_id when tasks moved under
+        # stages, so filtering on it raises FieldError for any recruitment that
+        # has tasks. Reach the recruitment through the task's stage instead.
         if tasks := OnboardingTask.objects.filter(
-            recruitment_id=candidate.recruitment_id
+            stage_id__recruitment_id=candidate.recruitment_id
         ):
             for task in tasks:
                 if not CandidateTask.objects.filter(
                     candidate_id=candidate, onboarding_task_id=task
                 ).exists():
                     CandidateTask(
-                        candidate_id=candidate, onboarding_task_id=task
+                        candidate_id=candidate,
+                        stage_id=task.stage_id,
+                        onboarding_task_id=task,
                     ).save()
 
     recruitment = candidate.recruitment_id
@@ -803,6 +808,7 @@ logger = logging.getLogger(__name__)
 def email_send(request):
     host = request.get_host()
     protocol = "https" if request.is_secure() else "http"
+    no_portal = request.GET.get("no_portal") == "True"
 
     candidates = request.POST.getlist("ids")
     other_attachments = request.FILES.getlist("other_attachments")
@@ -859,7 +865,9 @@ def email_send(request):
 
         # Create / reset portal
         token = secrets.token_hex(15)
-        portal, _ = OnboardingPortal.objects.get_or_create(candidate_id=candidate)
+        portal, _created = OnboardingPortal.objects.get_or_create(
+            candidate_id=candidate
+        )
         portal.token = token
         portal.used = False
         portal.count = 0
@@ -915,18 +923,25 @@ def email_send(request):
         except Exception as e:
             logger.error(f"Company logo attach failed: {e}")
 
-        # Send mail
-        try:
-            email.send()
-            messages.success(request, _("Portal link sent to the candidate"))
-        except Exception as e:
-            logger.error(e)
-            messages.error(
+        # Send mail, unless the caller only wants onboarding started. The
+        # "Start Onboarding" action posts ?no_portal=True for exactly this.
+        if no_portal:
+            messages.success(
                 request,
-                _("Mail not sent to %(candidate_name)s")
-                % {"candidate_name": candidate.name},
+                _("%(candidate)s added to onboarding") % {"candidate": candidate.name},
             )
-            # continue
+        else:
+            try:
+                email.send()
+                messages.success(request, _("Portal link sent to the candidate"))
+            except Exception as e:
+                logger.error(e)
+                messages.error(
+                    request,
+                    _("Mail not sent to %(candidate_name)s")
+                    % {"candidate_name": candidate.name},
+                )
+                # continue
 
         # Mark onboarding started without triggering Candidate.save() validation
         # (which can fail with "Choose valid choice" on job_position_id when the


### PR DESCRIPTION
## What happens

Pressing **+** ("Start Onboarding") on a hired candidate does nothing. No message, no stage, no error the user can see — the page reloads unchanged and the candidate stays out of the pipeline.

## Why

Three defects in `onboarding/views.py`, stacked.

**1. `_` is gettext, and `email_send()` overwrites it.**

```python
portal, _ = OnboardingPortal.objects.get_or_create(candidate_id=candidate)
```

From that line on `_` is a `bool`. The next statements to use it are the mail-send messages:

```python
messages.success(request, _("Portal link sent to the candidate"))
...
messages.error(request, _("Mail not sent to %(candidate_name)s") % ...)
```

so whichever branch runs raises `TypeError: 'bool' object is not callable`. That happens **before** the code that sets `start_onboard` and creates `CandidateStage`, so onboarding never begins. Reproduced on a 2.0 deployment: the POST fails and the candidate keeps `start_onboard=False`.

**2. `?no_portal=True` is ignored.**

The template posts it (`onboarding/templates/cbv/onboarding_candidates/actions.html`) precisely to add a candidate to onboarding *without* e-mailing a portal link, but the view never reads it — the only mention left is a commented-out line. So **+** builds and sends the same mail as the envelope action. Harmless while no SMTP is configured; once one is, **+** silently mails candidates.

**3. `candidates_single_view()` filters a field that no longer exists.**

```python
OnboardingTask.objects.filter(recruitment_id=candidate.recruitment_id)
```

`OnboardingTask` lost its own `recruitment_id` when tasks moved under stages, so this raises `FieldError` for any recruitment that has tasks.

## The change

- `portal, _created = ...` — nothing else in the function changes.
- `no_portal` honoured: onboarding starts, a message confirms it, no mail is sent.
- The task lookup goes through `stage_id__recruitment_id`, and the `CandidateTask` rows it creates carry that stage, like the live paths already do.

## Verified

On a 2.0 deployment, before: POST to `email-send?no_portal=True` fails, `start_onboard=False`, no `CandidateStage`. After: 200, `start_onboard=True`, candidate placed on the first stage, and `EmailLog` gains no rows.