### PR TITLE
fix(dashboard): charts lose their colours and drill-downs when the UI is translated

### DIFF
--- a/base/dashboard.py
+++ b/base/dashboard.py
@@ -722,6 +722,9 @@ def dashboard_gender_split(request):
                     "gender": gender_map.get(
                         item["gender"], item["gender"] or _("Not Specified")
                     ),
+                    # The name above is translated, so it cannot be used to look
+                    # up a colour or build a filter. Ship the raw field value too.
+                    "key": item["gender"] or "",
                     "count": item["count"],
                 }
             )

--- a/employee/views.py
+++ b/employee/views.py
@@ -3193,6 +3193,10 @@ def dashboard_employee(request):
             },
         ],
         "labels": labels,
+        # Stable, untranslated series keys. Consumers used to derive slice
+        # colours and the drill-down filter from the label text, which only
+        # works while the UI is English.
+        "keys": ["active", "inactive"],
     }
     return JsonResponse(response)
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -2480,19 +2480,19 @@
                 .then(r => r.json())
                 .then(data => {
                     if (!data.genders.length) { document.querySelector("#chart-gender").innerHTML = emptyHtml('{% trans "No data" %}'); return; }
-                    const gc = { 'Male': '#3b82f6', 'Female': '#ec4899', 'Other': '#a855f7', 'Not Specified': '#94a3b8' };
-                    const genderKeys = { 'Male': 'male', 'Female': 'female', 'Other': 'other', 'Not Specified': '' };
+                    {# keyed on the raw gender value: the name the API sends is translated #}
+                    const gc = { 'male': '#3b82f6', 'female': '#ec4899', 'other': '#a855f7', '': '#94a3b8' };
                     renderChart('gender', document.querySelector("#chart-gender"), {
                         series: data.genders.map(g => g.count),
                         chart: { type: 'donut', height: 300, background: 'transparent', fontFamily: 'inherit', animations: ANIM,
                             events: { dataPointSelection: (e, ctx, config) => {
                                 if (!PERM.employee) return;
-                                const gender = data.genders[config.dataPointIndex].gender;
-                                window.location.href = "{% url 'employee-view' %}?gender=" + (genderKeys[gender] || gender.toLowerCase());
+                                const g = data.genders[config.dataPointIndex];
+                                window.location.href = "{% url 'employee-view' %}?gender=" + encodeURIComponent(g.key != null ? g.key : g.gender.toLowerCase());
                             }}
                         },
                         labels: data.genders.map(g => g.gender),
-                        colors: data.genders.map(g => gc[g.gender] || '#94a3b8'),
+                        colors: data.genders.map(g => gc[g.key != null ? g.key : ''] || '#94a3b8'),
                         plotOptions: { pie: { expandOnClick: true, donut: { size: '68%',
                             labels: { show: true,
                                 name: { fontSize: '13px', fontWeight: 700, color: textColor },
@@ -2550,19 +2550,20 @@
                 .then(r => r.json())
                 .then(data => {
                     if (!data.dataSet || !data.dataSet.length) { document.querySelector("#chart-employee-status").innerHTML = emptyHtml('{% trans "No data" %}'); return; }
-                    const sc = { 'Active': '#22c55e', 'In-Active': '#ef4444', 'Inactive': '#ef4444' };
+                    {# keyed on the API's stable series keys, not on the translated labels #}
+                    const sc = { 'active': '#22c55e', 'inactive': '#ef4444' };
+                    const statusKeys = data.keys || ['active', 'inactive'];
                     renderChart('employee-status', document.querySelector("#chart-employee-status"), {
                         series: data.dataSet[0].data,
                         chart: { type: 'donut', height: 300, background: 'transparent', fontFamily: 'inherit', animations: ANIM,
                             events: { dataPointSelection: (e, ctx, config) => {
                                 if (!PERM.employee) return;
-                                const label = data.labels[config.dataPointIndex] || '';
-                                const active = label.toLowerCase().includes('active') && !label.toLowerCase().includes('in-') && !label.toLowerCase().includes('inactive') ? 'true' : 'false';
+                                const active = statusKeys[config.dataPointIndex] === 'active' ? 'true' : 'false';
                                 window.location.href = "{% url 'employee-view' %}?is_active=" + active;
                             }}
                         },
                         labels: data.labels,
-                        colors: data.labels.map(l => sc[l] || '#E54F38'),
+                        colors: statusKeys.map(k => sc[k] || '#94a3b8'),
                         plotOptions: { pie: { expandOnClick: true, donut: { size: '68%',
                             labels: { show: true,
                                 name: { fontSize: '13px', fontWeight: 700, color: textColor },


### PR DESCRIPTION
## What happens

Switch the interface to any non-English language and open the main dashboard:

- **Gender** renders as one flat grey pie.
- **Employee status** draws *both* Active and Inactive in the same red.
- Clicking a gender slice opens an employee list filtered by a translated word — no matches.
- Clicking a status slice always lands on the **inactive** list, whichever half you click.

Reported by an HR user right after we switched her interface to Ukrainian: *"the gender chart went colourless, and active/inactive need different colours."*

## Why

Both charts look up their colours by the label text, which the API has already translated:

```js
const gc = { 'Male': '#3b82f6', 'Female': '#ec4899', 'Other': '#a855f7', 'Not Specified': '#94a3b8' };
const sc = { 'Active': '#22c55e', 'In-Active': '#ef4444', 'Inactive': '#ef4444' };
```

Nothing matches `Чоловіча`, `Жіноча`, `Активний`, `Неактивний`, so every slice takes the fallback colour — and both status slices take the *same* fallback.

The status map having grown one entry per English spelling (`'In-Active'` beside `'Inactive'`) shows the shape of the problem: there is no spelling of "Active" that also covers de, fr, uk or ar.

The drill-downs share the flaw:

```js
window.location.href = "...?gender=" + (genderKeys[gender] || gender.toLowerCase());
const active = label.toLowerCase().includes('active') && !label.toLowerCase().includes('in-') && ... ;
```

`?gender=жіноча` matches nothing, and `includes('active')` is false for `Активний`, so every status click resolves to `is_active=false`.

## The change

Both endpoints now ship a stable, untranslated key next to the display label:

- `dashboard_gender_split` → `"key": "male" | "female" | "other" | ""`
- `dashboard_employee` → `"keys": ["active", "inactive"]`

The template keys colours and filters off those and uses labels only for display. Both are **new fields**, so any other consumer of these endpoints is unaffected.

## Verified

In a Ukrainian interface: gender renders `#3b82f6`/`#ec4899`, status renders `#22c55e`/`#ef4444`, no console errors, and both drill-downs land on the correct filtered list.