### PR TITLE
fix(employee): organisation chart shows a single node for most employees

### DIFF
--- a/employee/views.py
+++ b/employee/views.py
@@ -3823,6 +3823,33 @@ def organisation_chart(request):
 
     manager = request.user.employee_get
 
+    def top_of_chain(employee):
+        """Walk up the reporting chain and return the employee at the top of it."""
+        seen = {employee.id}
+        while True:
+            work_info = getattr(employee, "employee_work_info", None)
+            above = getattr(work_info, "reporting_manager_id", None)
+            # Bad data can point a chain back at itself; stop rather than spin.
+            if above is None or not above.is_active or above.id in seen:
+                return employee
+            seen.add(above.id)
+            employee = above
+
+    # Rooting the chart at the logged-in employee gives anyone with no
+    # subordinates a chart of exactly one node - themselves - which reads as a
+    # chart that failed to load. Root at the top of their reporting chain
+    # instead, so the chart shows the organisation they sit in. The dropdown and
+    # the POST branch below still re-root it wherever the user wants.
+    has_subordinates = (
+        Employee.objects.filter(
+            is_active=True, employee_work_info__reporting_manager_id=manager
+        )
+        .exclude(id=manager.id)
+        .exists()
+    )
+    if not has_subordinates:
+        manager = top_of_chain(manager)
+
     if len(reporting_managers) == 0:
         new_dict = {}
     else:

--- a/employee/views.py
+++ b/employee/views.py
@@ -3824,16 +3824,42 @@ def organisation_chart(request):
     manager = request.user.employee_get
 
     def top_of_chain(employee):
-        """Walk up the reporting chain and return the employee at the top of it."""
+        """Walk up the reporting chain, staying inside the employee's company.
+
+        The chart is company-scoped everywhere else in this view, so the walk
+        stops at a company boundary: without that, an employee of one company
+        who reports into another would be re-rooted onto that other company's
+        tree and shown staff they cannot otherwise see.
+
+        One query per hop, each pulling the next manager and their work info,
+        and a hard depth cap so a pathological chain cannot dominate the view.
+        """
+        max_depth = 30
+        start_company_id = getattr(
+            getattr(employee, "employee_work_info", None), "company_id_id", None
+        )
         seen = {employee.id}
-        while True:
-            work_info = getattr(employee, "employee_work_info", None)
+        for _ in range(max_depth):
+            work_info = (
+                EmployeeWorkInformation.objects.filter(employee_id=employee)
+                .select_related(
+                    "reporting_manager_id",
+                    "reporting_manager_id__employee_work_info",
+                )
+                .first()
+            )
             above = getattr(work_info, "reporting_manager_id", None)
             # Bad data can point a chain back at itself; stop rather than spin.
             if above is None or not above.is_active or above.id in seen:
                 return employee
+            above_company_id = getattr(
+                getattr(above, "employee_work_info", None), "company_id_id", None
+            )
+            if above_company_id != start_company_id:
+                return employee
             seen.add(above.id)
             employee = above
+        return employee
 
     # Rooting the chart at the logged-in employee gives anyone with no
     # subordinates a chart of exactly one node - themselves - which reads as a


### PR DESCRIPTION
## What happens

An employee opens **Employee → Organisation Chart** and sees one card: themselves. No hierarchy, no context. Our HR lead reported it as *"the org chart doesn't load"* — the page looks broken rather than empty.

## Why

The chart is rooted at the viewer:

```python
manager = request.user.employee_get
```

`create_hierarchy()` then walks *downwards* from that root. For anyone with no subordinates the result is a single node, and nothing on the page hints that the re-root dropdown is where the rest of the organisation is. In our install that was 40 of 54 employees.

## The change

When the logged-in employee has no subordinates, root at the top of their own reporting chain instead — so the chart opens on the organisation they sit in, with their own position visible inside it.

- Employees who **do** have subordinates get exactly the view they had.
- The dropdown and the `POST` branch still re-root the chart anywhere.
- The upward walk carries a `visited` set: reporting data that points a chain back at itself (A reports to B, B reports to A) would otherwise loop forever. Also stops at inactive managers.

## Verified

With a three-deep chain (top → mid → leaf):

| logged in as | before | after |
|---|---|---|
| leaf, no subordinates | `Leaf` alone | `Top → Mid → Leaf` |
| mid, has subordinates | `Mid → Leaf` | `Mid → Leaf` (unchanged) |

Cyclic reporting data returns a chart instead of hanging. On our production data the chart went from 1 node to all 54, six levels deep.