### PR TITLE
fix(recruitment): survey template description is saved but never shown

### DIFF
--- a/recruitment/templates/survey/survey_preview.html
+++ b/recruitment/templates/survey/survey_preview.html
@@ -18,6 +18,12 @@
                 {{template}} {% trans "Survey" %}
             </h1>
         </section>
+        {# the template's description is written in its form but was rendered nowhere #}
+        {% if template.description %}
+            <section class="oh-wrapper">
+                <p class="mb-3" style="color:#565E6C">{{ template.description }}</p>
+            </section>
+        {% endif %}
         {{form}}
     </form>
 </div>

--- a/recruitment/templates/survey/survey_preview_container.html
+++ b/recruitment/templates/survey/survey_preview_container.html
@@ -14,6 +14,9 @@
         {% trans "Back" %}
     </button>
 </div>
+{% if template.description %}
+    <p class="mb-3" style="color:#565E6C">{{ template.description }}</p>
+{% endif %}
 <div class="bg-white p-3 rounded-md shadow-card">
     {{form}}
 </div>


### PR DESCRIPTION
## What happens

`SurveyTemplate` has a `description` field, the template form offers it, and it saves fine. Then the person who wrote it never sees it again — including on the survey preview, which is where someone actually reads the questionnaire and where the context belongs.

An HR user put it as: *"In the questionnaire you can enter a description, but afterwards that text is nowhere."*

## Where it is and isn't rendered

Correcting the original wording of this PR, which claimed no template references the field at all — that was wrong, and the evidence behind it was bad (the `grep` I based it on never ran; my shell aborted the command on an unmatched glob and I read the empty output as a result).

The accurate picture on current `dev/v2.0`:

- `recruitment/templates/survey/templates.html:31` **does** contain `{{ template.description }}`.
- That template is **not rendered by anything**. No view, no `template_name`, no `{% include %}`, no `{% extends %}` reference it; the only mentions of the path in the repository are stale source references inside `horilla/locale/tr/.../django_translated.po`.
- The live templates page is `survey/view_question_templates.html` (`recruitment/cbv/recruitment_survey.py:209`, `recruitment/views/surveys.py:300`), and it does not render `description`.

So the field is reachable to write and unreachable to read.

## The change

Render it under the title in both preview variants:

- `recruitment/templates/survey/survey_preview.html` (standalone page)
- `recruitment/templates/survey/survey_preview_container.html` (HTMX container)

Guarded with `{% if template.description %}`, so nothing changes for templates without one.

## On `fix` vs `feat`

Happy to retitle to `feat(recruitment): show survey template description on the preview` if you still prefer it — it's your changelog. Flagging only that the "already visible in the list view" premise rests on a template nothing renders, so as far as a user is concerned the description is invisible today.