### PR TITLE
fix(theme): long list headings paint over the neighbouring columns

### DIFF
--- a/horilla_theme/static/horilla_theme/assets/css/v1_styles.css
+++ b/horilla_theme/static/horilla_theme/assets/css/v1_styles.css
@@ -4707,6 +4707,16 @@ a,
 .oh-tabs__movable-body .fixed-table thead th[id$="-rating_bar-header"] {
   min-width: 110px !important;
 }
+/* Generic list headers: the sortable heading's inner flex wrapper has the
+   default min-width:auto, so it never shrinks below its one-line width. In a
+   column pinned by an inline width (the onboarding date columns are 190px for
+   their <input type=date>) a long heading - Ukrainian labels especially -
+   paints straight across the neighbouring columns instead of wrapping. Let
+   the wrapper shrink; the text then wraps inside its own cell. */
+.fixed-table thead th > div > .flex {
+  min-width: 0;
+}
+
 /* Email keeps a readable width regardless */
 th[id$="-mail_indication-header"] {
   width: 280px;


### PR DESCRIPTION
## What happens

In **Onboarding → Hired Candidates** with a non-English UI, the column headings overlap each other: `Закінчення випробувального терміну` runs across the two headings to its right, so the header row is unreadable.

Reported by an HR user as *"the text in the column names has shifted."*

## Why

The sortable heading inside each generic-list `<th>` is a flex container, so it carries the default `min-width: auto` and never shrinks below its one-line width. Measured in the browser: the heading wanted **285px** inside a **190px** cell — the two date columns of that list are pinned to 190px to fit their `<input type="date">` widgets — and the overflow simply painted over the neighbours.

English labels are short enough to hide the problem; any translation with longer words exposes it.

## The change

```css
.fixed-table thead th > div > .flex { min-width: 0; }
```

The wrapper can now shrink, so the heading wraps inside its own cell. Body cells are untouched, so real content still defends its column width.

## Verified

Reproduced in the browser with Ukrainian labels, then confirmed the header row wraps within its cells and no other list regressed.