### PR TITLE
fix(employee): a policy that is only an attachment renders as a blank card

### DIFF
--- a/horilla_theme/templates/policies/records.html
+++ b/horilla_theme/templates/policies/records.html
@@ -54,7 +54,26 @@
                 </div>
 
                 <div class="h-80 overflow-hidden mb-3 border rounded-md p-4 sha">
-                    <p class="text-sm text-[#565E6C] mb-3">{{ policy.body|safe }}</p>
+                    {% if policy.body %}
+                        <p class="text-sm text-[#565E6C] mb-3">{{ policy.body|safe }}</p>
+                    {% endif %}
+                    {# a policy can be an attachment with no body, which used to render as a blank card #}
+                    {% with attachments=policy.attachments.all %}
+                        {% if attachments %}
+                            <div class="flex flex-wrap gap-2">
+                                {% for attachment in attachments %}
+                                    <a
+                                        href="{{ attachment.attachment.url }}"
+                                        rel="noopener noreferrer"
+                                        target="_blank"
+                                        class="oh-file-icon oh-file-icon--pdf"
+                                        style="width:40px;height:40px"
+                                        title="{% trans 'Open attachment' %}"
+                                    ></a>
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    {% endwith %}
                 </div>
 
                 <button


### PR DESCRIPTION
## What happens

Create a policy, attach a PDF, leave the body empty — the way a signed policy document is normally stored. The card on **Employee → Policies** comes out **empty**: title, then nothing.

An HR user reported it as *"if I upload a file it looks empty, but if I enter text, the text shows"* — and read it as the upload having failed.

## Why

The card template renders `policy.body` and nothing else. The attachments exist and are reachable from the detail modal, but the card gives no indication the policy has any content.

## The change

Render the attachments on the card when the policy has any, so a file-only policy looks like a policy. Policies with a body are unchanged.