### PR TITLE
fix(onboarding): page filters never reach the tab strip, and the page is named after recruitment

### DIFF
--- a/onboarding/cbv/pipeline.py
+++ b/onboarding/cbv/pipeline.py
@@ -63,7 +63,7 @@ class PipelineNav(HorillaNavView):
     """
 
     search_url = reverse_lazy("cbv-pipeline-tab-onboarding")
-    nav_title = _("Pipeline")
+    nav_title = _("Onboarding Tasks")
     search_swap_target = "#pipelineContainer"
     apply_first_filter = False
     filter_body_template = "cbv/pipeline/onboarding/filters.html"

--- a/onboarding/templates/cbv/pipeline/onboarding/pipeline.html
+++ b/onboarding/templates/cbv/pipeline/onboarding/pipeline.html
@@ -12,7 +12,8 @@
     <div
         class="oh-wrapper"
         id="pipelineContainer"
-        hx-get="{% url 'cbv-pipeline-tab-onboarding' %}"
+        {# forward the page's filters: this strip loads over HTMX from a fixed URL, so without them every request arrives unfiltered #}
+        hx-get="{% url 'cbv-pipeline-tab-onboarding' %}?{{ request.GET.urlencode }}"
         hx-trigger="load"
     >
     </div>


### PR DESCRIPTION
Two small, independent defects on the onboarding tasks page.

## 1. Filters never reach the tab strip

`pipeline.html` loads the strip over HTMX from a **fixed** URL:

```html
hx-get="{% url 'cbv-pipeline-tab-onboarding' %}"
hx-trigger="load"
```

`RecruitmentTabView.__init__` builds its tabs from `RecruitmentFilter(self.request.GET)` — but that is the *HTMX* request, which carries no query string. So:

- the sidebar entry links to `?closed=false` and that filter is silently dropped — the strip lists every active recruitment, including closed ones nobody is onboarding through;
- any filter the user applies on the page is ignored by the strip.

Forwarding the page's query string (`?{{ request.GET.urlencode }}`) makes it arrive.

## 2. The page is headed with recruitment wording

```python
nav_title = _("Pipeline")
```

That msgid is shared with recruitment's own pipeline, so translators render it as the recruitment funnel. In Ukrainian the **onboarding tasks** page is headed *«воронка підбору»* — "recruitment funnel". The msgid cannot be retranslated without breaking the recruitment page.

`_("Onboarding Tasks")` is what this page's own sidebar entry already says, and it is already translated in every catalog that carries the sidebar — so this is a one-line change with no new strings.

## Verified

With the query forwarded, `?closed=false` reaches the strip and closed recruitments drop out; the page heading matches its sidebar entry in both English and Ukrainian.