### PR TITLE
Bump djangorestframework to 3.17.2 to clear two CVEs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,14 @@ django-storages==1.14.6
 django-widget-tweaks==1.5.1
 
 # REST API
-djangorestframework==3.16.0
+# 3.17.2 clears CVE-2026-73228 (request.data bypasses Django's
+# DATA_UPLOAD_MAX_MEMORY_SIZE for JSON and urlencoded bodies, so an
+# oversized payload is parsed instead of rejected) and CVE-2026-73229
+# (AdminRenderer invokes a view's GET handler while rendering a 400 on an
+# invalid write, disclosing data the caller's permissions deny on GET --
+# not reachable here, since no view sets AdminRenderer, but pinned past it
+# anyway rather than relying on that staying true).
+djangorestframework==3.17.2
 # 5.5.1, not 5.5.0: 5.5.0 caps pyjwt<2.10.0, which pins the JWT library to
 # a version with the advisories below. 5.5.1 drops the cap (pyjwt>=1.7.1).
 djangorestframework-simplejwt==5.5.1


### PR DESCRIPTION
`dependency-audit` has been failing on `dev/v2.0` since two DRF advisories were published, so it is currently red on **every** PR anyone opens. One-line pin bump.

## The advisories

**CVE-2026-73228** — DRF hands the raw Django `HttpRequest` to its parsers, which consume the stream via `HttpRequest.read()` instead of the guarded `request.body` path. `DATA_UPLOAD_MAX_MEMORY_SIZE` is therefore not enforced for `application/json` or `application/x-www-form-urlencoded`: `request.data` parses an oversized payload that `request.body` would reject. Availability impact only; `multipart/form-data` is unaffected.

**CVE-2026-73229** — `AdminRenderer` renders a 400 on an invalid write by overriding the request method and calling `view.get()` directly, bypassing `APIView.dispatch` and its permission check. A view that permits POST while denying GET can disclose its GET representation. **Not reachable in this codebase** — no view sets `AdminRenderer` — but pinning past it rather than depending on that staying true.

## Verification

- `pip-audit` against the bumped requirements, using the same `--ignore-vuln PYSEC-2026-2860` flag CI uses: **"No known vulnerabilities found"**.
- **368 tests pass** across `report`, `base`, `horilla_views`, `employee`, `attendance`, `payroll`, `leave`, `recruitment`, `offboarding`, `horilla_theme` and `horilla_api` — the last being the entire DRF-facing surface.
- `drf-yasg` (`>=3.13`) and `djangorestframework-simplejwt` (`>=3.14`) declare no upper bound, so neither constrains the bump.

3.18.0 is available, but 3.17.2 is the minimum that clears both advisories — smaller change, less breakage surface.

Rationale is recorded inline beside the pin, matching the convention the surrounding CVE pins already follow.