### PR TITLE
Keep employee names out of attendance logs, replace prints with logging

### DIFF
--- a/attendance/scheduler.py
+++ b/attendance/scheduler.py
@@ -89,7 +89,13 @@ def create_work_record():
             )
             records_to_create.append(record)
         except Exception as e:
-            logger.error(f"Error preparing work record for {employee}: {e}")
+            # Employee.__str__ is "Name (BADGE)", so interpolating the
+            # object writes a real name into the log. The id is enough to
+            # find the row, and logger.exception keeps the traceback.
+            logger.exception(
+                "Error preparing work record for employee_id=%s",
+                getattr(employee, "pk", employee),
+            )
 
     if records_to_create:
         try:

--- a/attendance/signals.py
+++ b/attendance/signals.py
@@ -1,5 +1,6 @@
 # attendance/signals.py
 
+import logging
 from datetime import datetime, timedelta
 
 from django.apps import apps
@@ -12,6 +13,8 @@ from attendance.models import Attendance, AttendanceGeneralSetting, WorkRecords
 from base.models import Company, PenaltyAccounts
 from employee.models import Employee
 from horilla.methods import get_horilla_model_class
+
+logger = logging.getLogger(__name__)
 
 
 @receiver(post_save, sender=Attendance)
@@ -60,7 +63,7 @@ def attendance_post_save(sender, instance, **kwargs):
             WorkRecords._base_manager.filter(id__in=ids).delete()
 
     except Exception as e:
-        print(e)
+        logger.exception("Work record signal failed")
 
     work_record.employee_id = instance.employee_id
     work_record.date = instance.attendance_date
@@ -132,12 +135,13 @@ def add_missing_attendance_to_workrecord(sender, **kwargs):
             WorkRecords.objects.bulk_update(
                 records_to_update, ["attendance_id"], batch_size=500
             )
-            print(
-                f"Successfully updated {len(records_to_update)} work records with attendance information."
+            logger.info(
+                "Updated %s work records with attendance information",
+                len(records_to_update),
             )
 
     except Exception as e:
-        print(f"Error updating work records with attendance: {e}")
+        logger.exception("Error updating work records with attendance")
 
 
 # @receiver(post_migrate)
@@ -167,12 +171,13 @@ def add_missing_shift_to_work_record(sender, **kwargs):
             WorkRecords.objects.bulk_update(
                 records_to_update, ["shift_id"], batch_size=500
             )
-            print(
-                f"Successfully updated {len(records_to_update)} work records with shift information."
+            logger.info(
+                "Updated %s work records with shift information",
+                len(records_to_update),
             )
 
     except Exception as e:
-        print(f"Error updating work records with shift information: {e}")
+        logger.exception("Error updating work records with shift information")
 
 
 @receiver(post_save, sender=Company)
@@ -231,6 +236,7 @@ def create_missing_work_records(sender, **kwargs):
                     )
 
             except Exception as e:
-                print(
-                    f"Error creating missing work records for employee {employee}: {e}"
+                logger.exception(
+                    "Error creating missing work records for employee_id=%s",
+                    getattr(employee, "pk", employee),
                 )


### PR DESCRIPTION
Clears the two `py/clear-text-logging-sensitive-data` alerts (high) that CodeQL reports on `dev/v2.0`.

Both interpolated an `Employee` object into a log line, and `Employee.__str__` renders `"Name (BADGE)"` — so a routine error wrote a real person's name and badge id into the log:

```
attendance/scheduler.py:92   logger.error(f"... for {employee}: {e}")
attendance/signals.py:235    print(f"... for employee {employee}: {e}")
```

Both now log the primary key, which is enough to find the row, and use `logger.exception` so the traceback survives rather than only the exception's `str()`.

**While in `signals.py`:** it had no logger at all and six bare `print()` calls. Those bypass logging configuration entirely — no level, no handler, invisible to any log aggregator, unsuppressable in production. All six now go through a module logger. Only the employee one leaked PII; the rest are converted for operability.

232 tests pass across `attendance`, `base` and `report`.