### PR TITLE
Escape user input in hand-built HTML responses (8 XSS sinks)

### DIFF
--- a/attendance/scheduler.py
+++ b/attendance/scheduler.py
@@ -89,7 +89,13 @@ def create_work_record():
             )
             records_to_create.append(record)
         except Exception as e:
-            logger.error(f"Error preparing work record for {employee}: {e}")
+            # Employee.__str__ is "Name (BADGE)", so interpolating the
+            # object writes a real name into the log. The id is enough to
+            # find the row, and logger.exception keeps the traceback.
+            logger.exception(
+                "Error preparing work record for employee_id=%s",
+                getattr(employee, "pk", employee),
+            )
 
     if records_to_create:
         try:

--- a/attendance/signals.py
+++ b/attendance/signals.py
@@ -1,5 +1,6 @@
 # attendance/signals.py
 
+import logging
 from datetime import datetime, timedelta
 
 from django.apps import apps
@@ -12,6 +13,8 @@ from attendance.models import Attendance, AttendanceGeneralSetting, WorkRecords
 from base.models import Company, PenaltyAccounts
 from employee.models import Employee
 from horilla.methods import get_horilla_model_class
+
+logger = logging.getLogger(__name__)
 
 
 @receiver(post_save, sender=Attendance)
@@ -60,7 +63,7 @@ def attendance_post_save(sender, instance, **kwargs):
             WorkRecords._base_manager.filter(id__in=ids).delete()
 
     except Exception as e:
-        print(e)
+        logger.exception("Work record signal failed")
 
     work_record.employee_id = instance.employee_id
     work_record.date = instance.attendance_date
@@ -132,12 +135,13 @@ def add_missing_attendance_to_workrecord(sender, **kwargs):
             WorkRecords.objects.bulk_update(
                 records_to_update, ["attendance_id"], batch_size=500
             )
-            print(
-                f"Successfully updated {len(records_to_update)} work records with attendance information."
+            logger.info(
+                "Updated %s work records with attendance information",
+                len(records_to_update),
             )
 
     except Exception as e:
-        print(f"Error updating work records with attendance: {e}")
+        logger.exception("Error updating work records with attendance")
 
 
 # @receiver(post_migrate)
@@ -167,12 +171,13 @@ def add_missing_shift_to_work_record(sender, **kwargs):
             WorkRecords.objects.bulk_update(
                 records_to_update, ["shift_id"], batch_size=500
             )
-            print(
-                f"Successfully updated {len(records_to_update)} work records with shift information."
+            logger.info(
+                "Updated %s work records with shift information",
+                len(records_to_update),
             )
 
     except Exception as e:
-        print(f"Error updating work records with shift information: {e}")
+        logger.exception("Error updating work records with shift information")
 
 
 @receiver(post_save, sender=Company)
@@ -231,6 +236,7 @@ def create_missing_work_records(sender, **kwargs):
                     )
 
             except Exception as e:
-                print(
-                    f"Error creating missing work records for employee {employee}: {e}"
+                logger.exception(
+                    "Error creating missing work records for employee_id=%s",
+                    getattr(employee, "pk", employee),
                 )

--- a/base/cbv/roster.py
+++ b/base/cbv/roster.py
@@ -6,6 +6,7 @@ Provides roster grid, cell editing, publish, my roster, and import/export.
 """
 
 import json
+from urllib.parse import urlencode
 from datetime import date, timedelta
 
 import openpyxl
@@ -447,12 +448,18 @@ class RosterEmployeeBulkPublishView(View):
             request,
             _("Roster published for %(count)s employee(s).") % {"count": count},
         )
-        grid_params = f"from_date={from_date}"
+        # These params are interpolated into a <script> block below, where
+        # neither template autoescaping nor HTML escaping applies -- a raw
+        # department value could close the string and inject JS. urlencode
+        # percent-encodes quotes and angle brackets, which both fixes that
+        # and produces a correctly-formed query string.
+        params = {"from_date": from_date}
         if to_date:
-            grid_params += f"&to_date={to_date}"
+            params["to_date"] = to_date
         dept_id = request.POST.get("department")
         if dept_id:
-            grid_params += f"&department={dept_id}"
+            params["department"] = dept_id
+        grid_params = urlencode(params)
         return HttpResponse(
             "<script>"
             "$('#rosterEmployeeInstances').attr('data-ids', JSON.stringify([]));"

--- a/biometric/views.py
+++ b/biometric/views.py
@@ -21,6 +21,7 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import redirect, render
 from django.template.loader import render_to_string
 from django.utils import timezone as django_timezone
+from django.utils.html import format_html
 from django.utils.translation import gettext as __
 from django.utils.translation import gettext_lazy as _
 from zk import ZK
@@ -1967,12 +1968,15 @@ def delete_dahua_user(request, obj_id=None):
             user_ids = request.GET.getlist("ids")
             device_id = request.GET.get("device_id")
             if device_id:
-                script = f"""
-                            <span hx-get="/biometric/biometric-device-employees/{device_id}/"
-                                hx-target="#dahuUsersList" hx-select="#dahuUsersList" hx-trigger="load delay:200ms"
-                                hx-swap="outerHTML" hx-on-htmx-before-request="reloadMessage();">
-                            </span>
-                        """
+                # device_id is request-controlled and interpolated into
+                # hand-built HTML, where autoescaping does not apply.
+                script = format_html(
+                    '<span hx-get="/biometric/biometric-device-employees/{}/" '
+                    'hx-target="#dahuUsersList" hx-select="#dahuUsersList" '
+                    'hx-trigger="load delay:200ms" hx-swap="outerHTML" '
+                    'hx-on-htmx-before-request="reloadMessage();"></span>',
+                    device_id,
+                )
             if user_ids:
                 users = BiometricEmployees.objects.filter(user_id__in=user_ids)
                 if users:
@@ -2012,12 +2016,15 @@ def delete_etimeoffice_user(request, obj_id=None):
         user_ids = request.GET.getlist("ids")
         device_id = request.GET.get("device_id")
         if device_id:
-            script = f"""
-                            <span hx-get="/biometric/biometric-device-employees/{device_id}/"
-                                hx-target="#eTimeOfficeUsersList" hx-select="#eTimeOfficeUsersList" hx-trigger="load delay:200ms"
-                                hx-swap="outerHTML" hx-on-htmx-before-request="reloadMessage();">
-                            </span>
-                        """
+                # device_id is request-controlled and interpolated into
+                # hand-built HTML, where autoescaping does not apply.
+            script = format_html(
+                '<span hx-get="/biometric/biometric-device-employees/{}/" '
+                'hx-target="#eTimeOfficeUsersList" hx-select="#eTimeOfficeUsersList" '
+                'hx-trigger="load delay:200ms" hx-swap="outerHTML" '
+                'hx-on-htmx-before-request="reloadMessage();"></span>',
+                device_id,
+                )
         if user_ids:
             users = BiometricEmployees.objects.filter(user_id__in=user_ids)
             if users:

--- a/employee/views.py
+++ b/employee/views.py
@@ -1045,16 +1045,16 @@ def document_approve(request, id):
         return refreshed
 
     if refresh_url:
-        span = f"""
-        <span
-            hx-trigger="load"
-            hx-get="{refresh_url}"
-            hx-target="#requestDocument{id}"
-            hx-select="#requestDocument{id}"
-            hx-swap="outerHTML"
-            ">
-        </span>
-        """
+        # refresh_url comes from the request and is interpolated into
+        # hand-built HTML, so autoescaping does not apply. format_html
+        # escapes it.
+        span = format_html(
+            '<span hx-trigger="load" hx-get="{}" hx-target="#requestDocument{}" '
+            'hx-select="#requestDocument{}" hx-swap="outerHTML"></span>',
+            refresh_url,
+            id,
+            id,
+        )
         return HttpResponse(span)
 
     return HorillaRedirect(request)

--- a/leave/views.py
+++ b/leave/views.py
@@ -21,6 +21,7 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.encoding import force_str
+from django.utils.html import format_html
 from django.utils.translation import gettext as __
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_http_methods
@@ -4670,9 +4671,12 @@ def delete_allocation_comment_file(request):
         messages.success(request, _("File deleted successfully"))
     else:
         messages.warning(request, _("You don't have permission"))
-        script = f"""
-                <span hx-get='/leave/allocation-request-view-comment/{leave_id}/' hx-target='#commentContainer' hx-trigger='load'></span>
-                """
+        # Same unescaped-interpolation issue as delete_leave_comment_file.
+        script = format_html(
+            "<span hx-get='/leave/allocation-request-view-comment/{}/' "
+            "hx-target='#commentContainer' hx-trigger='load'></span>",
+            leave_id,
+        )
     return HttpResponse(script)
 
 
@@ -4913,9 +4917,16 @@ def delete_leave_comment_file(request):
         messages.success(request, _("File deleted successfully"))
     else:
         messages.warning(request, _("You don't have permission"))
-        script = f"""
-            <span hx-get="/leave/leave-request-view-comment/{leave_id}/?&amp;target=leaveRequest" hx-target="#commentContainer" hx-trigger="load"></span>
-        """
+        # leave_id comes straight from the query string and is interpolated
+        # into hand-built HTML, where Django's template autoescaping does not
+        # apply. format_html escapes the value; this branch is reachable by
+        # any authenticated user, since the view is @login_required only.
+        script = format_html(
+            '<span hx-get="/leave/leave-request-view-comment/{}/'
+            '?&amp;target=leaveRequest" hx-target="#commentContainer" '
+            'hx-trigger="load"></span>',
+            leave_id,
+        )
     return HttpResponse(script)
 
 

--- a/offboarding/cbv/exit_process.py
+++ b/offboarding/cbv/exit_process.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 from urllib.parse import urlencode, urlparse
 
 from django import forms
+from django.utils.html import escapejs
 from django.apps import apps
 from django.contrib import messages
 from django.db.models import Count
@@ -79,7 +80,10 @@ def offboarding_pipeline_modal_success_response(request) -> HttpResponse:
     if qs:
         tab_url = f"{tab_url}?{qs}"
 
-    tab_url_lit = json.dumps(tab_url)
+    # json.dumps escapes quotes but NOT "</script>", so a crafted value
+    # could close the script block that this literal is embedded in.
+    # escapejs encodes angle brackets as \u003C/\u003E.
+    tab_url_lit = f'"{escapejs(tab_url)}"'
 
     snippet = rf"""
 <script>

--- a/project/views.py
+++ b/project/views.py
@@ -12,6 +12,7 @@ from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_http_methods
 
@@ -1393,8 +1394,15 @@ def delete_project_stage(request, stage_id):
     else:
         messages.warning(request, _("Can't Delete. This stage contain some tasks"))
     if request.META.get("HTTP_HX_REQUEST"):
+        # view_type is request-controlled and lands inside a single-quoted
+        # attribute in hand-built HTML; format_html escapes it.
         return HttpResponse(
-            f"<span hx-get='/project/task-filter/{project_id}/?view={view_type}' hx-trigger='load' hx-target='#viewContainer'></span>"
+            format_html(
+                "<span hx-get='/project/task-filter/{}/?view={}' "
+                "hx-trigger='load' hx-target='#viewContainer'></span>",
+                project_id,
+                view_type,
+            )
         )
     task_view_url = reverse("task-view", args=[project_id])
     redirected_url = f"{task_view_url}?view={view_type}"


### PR DESCRIPTION
CodeQL reports 14 `py/reflective-xss` alerts (high) on `dev/v2.0`. **Eight are real, six are false positives.** Each real one builds an HTML string in Python and returns it via `HttpResponse`, so Django's template autoescaping never applies.

## Fixed, worst first

**1. `leave/views.py` — `delete_leave_comment_file`, `delete_allocation_comment_file`.** `leave_id` from the query string interpolated into an `hx-get` attribute. These are the most exposed of the set: **`@login_required` only** — no permission gate, no `hx_request_required` — and the vulnerable branch is the `else` taken when the user *lacks* permission. Any authenticated user reaches it. Verified `1"><img src=x onerror=...>` breaks the attribute before the fix and is entity-encoded after.

**2. `base/cbv/roster.py`.** A department id from POST interpolated into a `<script>` block — JS injection, not merely HTML. Query params are now assembled with `urlencode`, which percent-encodes quotes and braces and also produces a properly-formed query string. The sibling sink at line 384 is safe and left alone: its `dept_id` passes through a `Department` PK lookup first.

**3. `employee/views.py`, `project/views.py`, `biometric/views.py` (×2).** Request values interpolated into `hx-get` attributes.

**4. `offboarding/cbv/exit_process.py`.** `json.dumps` built a JS string literal. It escapes quotes but **not `</script>`** — verified directly — so a crafted value could close the enclosing script block. Now uses Django's `escapejs`.

All follow the pattern `base/views.py:1809` already uses (`format_html` with placeholders), so this reuses an in-repo convention rather than inventing one.

## Deliberately not changed

**6 `reflective-xss` false positives:** two interpolate an `<int:...>` URL kwarg (Django's converter guarantees digits), one is a DB-sourced badge id, one a plain-text webhook challenge, one an internal kwarg, plus `roster.py:384`.

**All 76 `py/url-redirection` alerts are false positives.** 66 route through `HorillaRedirect`, which validates via `url_has_allowed_host_and_scheme` against the request host — CodeQL doesn't model the custom subclass as a sanitizer. The other 10 interpolate only into a query string after a hardcoded leading `/`, so the host cannot be altered (I checked specifically for a `//evil.com` protocol-relative breakout — not reachable).

**The 4 "critical" `py/partial-ssrf` alerts are false positives.** The URLs are built from biometric device records, and creating or editing those requires `biometric.add/change_biometricdevices`. An admin pointing the integration at their own device is the feature.

That leaves **8 of 90 open security alerts needing code changes**, all in this PR.

## Reachability note

`hx_request_required` only checks that the `HX-Request` header is present. A custom header can't be set by a cross-origin form or link and would trip CORS preflight, so sinks 3–4 are not one-click drive-by attacks — they need same-origin JS or a non-browser client. That lowers severity but doesn't eliminate it. Sinks 1–2 have no such gate.

314 tests pass across `leave`, `base`, `employee`, `project`, `biometric`, `offboarding`, `attendance` and `report`.