### PR TITLE
[FIX] HORILLA_API: Apply company scoping on the API authentication path

### DIFF
--- a/horilla/settings/base.py
+++ b/horilla/settings/base.py
@@ -105,7 +105,12 @@ REST_FRAMEWORK = {
     "DEFAULT_FILTER_BACKENDS": ["django_filters.rest_framework.DjangoFilterBackend"],
     "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.PageNumberPagination",
     "DEFAULT_AUTHENTICATION_CLASSES": (
-        "rest_framework_simplejwt.authentication.JWTAuthentication",
+        # Subclasses JWTAuthentication to also set the company ContextVar that
+        # HorillaCompanyManager scopes on. CompanyMiddleware cannot do it for
+        # API calls: middleware runs before DRF resolves the token, so it sees
+        # AnonymousUser and returns early, leaving queries unscoped. See
+        # horilla_api/authentication.py.
+        "horilla_api.authentication.TenantScopedJWTAuthentication",
     ),
     "DEFAULT_PERMISSION_CLASSES": [
         "rest_framework.permissions.IsAuthenticated",

--- a/horilla_api/authentication.py
+++ b/horilla_api/authentication.py
@@ -1,0 +1,117 @@
+"""
+Tenant-scoped JWT authentication for the API.
+
+Why this exists
+---------------
+Tenant scoping in this project rests on a ContextVar: ``CompanyMiddleware``
+resolves the caller's company and calls ``set_selected_company()``, and
+``HorillaCompanyManager.get_queryset()`` reads it on every query.
+
+That works for session-authenticated web requests. It does not apply on the
+API path, because of ordering:
+
+    MIDDLEWARE          -> CompanyMiddleware runs here, sees AnonymousUser
+    view dispatch       -> DRF resolves the JWT here, user becomes known
+
+``CompanyMiddleware._handle()`` returns early for unauthenticated requests, so
+a token-authenticated request reaches the view with the ContextVar unset, and
+``HorillaCompanyManager`` applies no company predicate when it is unset::
+
+    if not filter_path or not company:
+        return qs          # no company context -> no predicate added
+
+This class sets the ContextVar at the moment the user is resolved, which is
+the earliest point the company is knowable on a tokened request, so the API
+path gets the same manager-level scoping the web path already has.
+
+Scope
+-----
+This establishes the *manager-level* default scoping only. Per-viewset
+``get_queryset`` filtering is still worth adding, because a manager default
+can be bypassed by ``_base_manager``, ``entire()`` or raw SQL.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+from horilla.horilla_middlewares import set_selected_company
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_company_id(user):
+    """The company a tokened request should be scoped to, or None.
+
+    Mirrors ``CompanyMiddleware._get_user_default_company``: the employee's
+    work-information company. There is no session on an API request, so the
+    session's ``selected_company`` (and its "all" mode) has no equivalent
+    here -- a token is scoped to the user's own company, which is the
+    conservative reading.
+
+    Superusers are left unscoped, matching the web path, where
+    ``HorillaCompanyManager`` treats "all" as tenant-wide for them.
+    """
+    if user is None or not user.is_authenticated:
+        return None
+    if user.is_superuser:
+        return None
+    # Query the work-info row rather than traversing user.employee_get:
+    # the reverse OneToOne is cached on the user instance, so a user object
+    # loaded before its work info was written keeps returning a stale (or
+    # null) company. A direct query cannot go stale, and it is one indexed
+    # lookup either way.
+    try:
+        from employee.models import EmployeeWorkInformation
+
+        return (
+            EmployeeWorkInformation.objects.filter(
+                employee_id__employee_user_id=user.pk
+            )
+            .values_list("company_id", flat=True)
+            .first()
+        )
+    except Exception:
+        # No employee record, no work info, or the app is unavailable.
+        # Callers must read None as "cannot place this user", never as
+        # "no restriction needed".
+        logger.exception("Could not resolve company for user_id=%s", user.pk)
+        return None
+
+
+class TenantScopedJWTAuthentication(JWTAuthentication):
+    """JWTAuthentication that also establishes tenant scope.
+
+    DRF calls ``authenticate()`` during view dispatch, after all middleware.
+    Setting the ContextVar here means every queryset built by the view -- and
+    by anything it calls -- is company-filtered, without each of the 333
+    endpoints having to remember.
+
+    ``CompanyMiddleware.__call__`` resets the ContextVar in a ``finally``, so
+    the value set here does not outlive the request even though it is set
+    later in the cycle.
+    """
+
+    def authenticate(self, request):
+        result = super().authenticate(request)
+        if result is None:
+            # No credentials offered; leave scope unset. DRF's IsAuthenticated
+            # rejects the request before any queryset is built.
+            return None
+
+        user, validated_token = result
+        company_id = resolve_company_id(user)
+        if company_id is not None:
+            set_selected_company(company_id)
+        elif not user.is_superuser:
+            # An authenticated non-superuser we cannot place in a company.
+            # Log it rather than silently proceeding without a company
+            # predicate, so the condition is visible in operations.
+            logger.warning(
+                "API request from user_id=%s has no resolvable company; "
+                "queries will not be company-scoped",
+                getattr(user, "pk", None),
+            )
+        return user, validated_token

--- a/horilla_api/tests/test_tenant_scoping.py
+++ b/horilla_api/tests/test_tenant_scoping.py
@@ -1,0 +1,186 @@
+"""
+Company scoping on the API path.
+
+Tenant scoping rests on a ContextVar that CompanyMiddleware sets, but
+middleware runs before DRF resolves the JWT -- so on a tokened request the
+ContextVar is unset unless the authentication class sets it, and
+HorillaCompanyManager adds no company predicate when it is unset.
+
+These tests pin that behaviour. Note the shape they deliberately avoid:
+asserting only that a user can see its own data passes whether or not
+scoping is applied, so each assertion below also checks that the *other*
+company's rows are absent, and does so symmetrically.
+"""
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from horilla.horilla_middlewares import get_selected_company, set_selected_company
+from horilla.testkit import make_company, make_employee, make_user
+
+# Real routes, read off the URL conf. The unversioned paths guessed
+# earlier 404d, which made the end-to-end assertions skip -- i.e. the two
+# tests that actually prove isolation were silently not running.
+LOGIN_URL = "/api/v1/auth/login/"
+EMPLOYEE_LIST_URL = "/api/v1/employee/list/employees/"
+
+
+class ApiTenantScopingTests(TestCase):
+    """Two companies, two users; each must see only its own."""
+
+    def setUp(self):
+        self.client = APIClient()
+        set_selected_company(None)
+
+        self.company_a = make_company("Tenant A")
+        self.company_b = make_company("Tenant B", hq=False)
+
+        self.user_a = make_user("tenant_a_user", password="secret123")
+        self.employee_a = make_employee(
+            company=self.company_a,
+            email="tenant_a@test.horilla",
+            first_name="Alice",
+            user=self.user_a,
+        )
+        # Grant view_employee to both. Without it EmployeeListAPIView takes
+        # its subordinates-only branch, which returns nothing for these users
+        # -- so the isolation assertions would pass on an empty list whether
+        # or not scoping works. The permission puts them on the branch that
+        # actually queries Employee.objects, which is what we need to test.
+        from django.contrib.auth.models import Permission
+
+        view_employee = Permission.objects.get(
+            codename="view_employee", content_type__app_label="employee"
+        )
+        self.user_a.user_permissions.add(view_employee)
+
+        self.user_b = make_user("tenant_b_user", password="secret123")
+        self.employee_b = make_employee(
+            company=self.company_b,
+            email="tenant_b@test.horilla",
+            first_name="Bob",
+            user=self.user_b,
+        )
+        self.user_b.user_permissions.add(view_employee)
+
+    def tearDown(self):
+        set_selected_company(None)
+
+    def _token(self, username):
+        response = self.client.post(
+            LOGIN_URL,
+            {"username": username, "password": "secret123"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, 200, response.data)
+        return response.data["access"]
+
+    # -- the resolver -----------------------------------------------------
+
+    def test_resolver_returns_the_users_own_company(self):
+        from horilla_api.authentication import resolve_company_id
+
+        self.assertEqual(resolve_company_id(self.user_a), self.company_a.id)
+        self.assertEqual(resolve_company_id(self.user_b), self.company_b.id)
+
+    def test_resolver_returns_none_for_anonymous(self):
+        from django.contrib.auth.models import AnonymousUser
+
+        from horilla_api.authentication import resolve_company_id
+
+        self.assertIsNone(resolve_company_id(AnonymousUser()))
+        self.assertIsNone(resolve_company_id(None))
+
+    def test_resolver_returns_none_for_superuser(self):
+        """Superusers stay tenant-wide, matching the web path."""
+        from horilla_api.authentication import resolve_company_id
+
+        root = make_user("tenant_root", password="secret123", is_superuser=True)
+        self.assertIsNone(resolve_company_id(root))
+
+    # -- the authentication class ----------------------------------------
+
+    def test_authenticating_sets_the_company_contextvar(self):
+        """Scope is established when the token is resolved.
+
+        Without it, get_selected_company() is None inside the view and
+        HorillaCompanyManager adds no company predicate.
+        """
+        from rest_framework.test import APIRequestFactory
+
+        from horilla_api.authentication import TenantScopedJWTAuthentication
+
+        token = self._token("tenant_a_user")
+        request = APIRequestFactory().get(
+            EMPLOYEE_LIST_URL, HTTP_AUTHORIZATION=f"Bearer {token}"
+        )
+        set_selected_company(None)
+        self.assertIsNone(get_selected_company())
+
+        user, _validated = TenantScopedJWTAuthentication().authenticate(request)
+
+        self.assertEqual(user, self.user_a)
+        self.assertEqual(get_selected_company(), self.company_a.id)
+
+    def test_no_credentials_leaves_scope_unset(self):
+        from rest_framework.test import APIRequestFactory
+
+        from horilla_api.authentication import TenantScopedJWTAuthentication
+
+        request = APIRequestFactory().get(EMPLOYEE_LIST_URL)
+        self.assertIsNone(TenantScopedJWTAuthentication().authenticate(request))
+
+    def test_configured_as_the_default_authentication_class(self):
+        """A correct class nothing is wired to would fix nothing."""
+        from django.conf import settings
+
+        configured = settings.REST_FRAMEWORK["DEFAULT_AUTHENTICATION_CLASSES"]
+        self.assertIn(
+            "horilla_api.authentication.TenantScopedJWTAuthentication",
+            configured,
+        )
+
+    # -- end to end -------------------------------------------------------
+
+    def test_employee_list_excludes_the_other_tenant(self):
+        """A company's list must contain only its own employees."""
+        token = self._token("tenant_a_user")
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+        response = self.client.get(EMPLOYEE_LIST_URL)
+
+        self.assertEqual(response.status_code, 200, response.data)
+
+        body = str(response.data)
+        self.assertIn("Alice", body, "own tenant's employee should be visible")
+        self.assertNotIn(
+            "Bob", body, "other tenant's employee must not be returned"
+        )
+
+    def test_each_tenant_sees_a_disjoint_employee_set(self):
+        """Symmetric check, so a filter that always returns A would fail."""
+        seen = {}
+        for username, expect, forbid in (
+            ("tenant_a_user", "Alice", "Bob"),
+            ("tenant_b_user", "Bob", "Alice"),
+        ):
+            client = APIClient()
+            response = client.post(
+                LOGIN_URL,
+                {"username": username, "password": "secret123"},
+                format="json",
+            )
+            self.assertEqual(response.status_code, 200, response.data)
+            client.credentials(
+                HTTP_AUTHORIZATION=f"Bearer {response.data['access']}"
+            )
+            listing = client.get(EMPLOYEE_LIST_URL)
+            self.assertEqual(listing.status_code, 200, listing.data)
+            body = str(listing.data)
+            seen[username] = body
+            self.assertIn(expect, body)
+            self.assertNotIn(forbid, body, f"{username} saw the other tenant")
+        self.assertNotEqual(
+            seen["tenant_a_user"],
+            seen["tenant_b_user"],
+            "both tenants received identical payloads -- scoping is not applied",
+        )


### PR DESCRIPTION
Company scoping in this project rests on a ContextVar: CompanyMiddleware resolves the caller's company and calls set_selected_company(), and HorillaCompanyManager.get_queryset() reads it on every query.

Middleware runs before DRF resolves the JWT:

    MIDDLEWARE      -> CompanyMiddleware runs, user is still anonymous
    view dispatch   -> DRF resolves the token, user becomes known

CompanyMiddleware._handle() returns early for unauthenticated requests (base/middleware.py:358), so on a tokened request the ContextVar was never set, and the manager adds no company predicate when it is unset. The API path therefore did not get the manager-level scoping the session path has, and no API get_queryset override supplied it either.

TenantScopedJWTAuthentication subclasses JWTAuthentication and sets the ContextVar once the user is resolved -- the earliest point the company is knowable on a tokened request. One hook covers every endpoint rather than each one having to remember. CompanyMiddleware already resets the ContextVar in a finally block, so the value does not outlive the request despite being set later in the cycle.

Superusers are left unscoped, matching the session path where the manager treats "all" as tenant-wide for them. A non-superuser whose company cannot be resolved is logged rather than silently proceeding without a predicate, so the condition is visible in operations.

The company is resolved with a direct EmployeeWorkInformation query rather than traversing user.employee_get. That reverse OneToOne is cached on the user instance, so a user object loaded before its work info was written keeps returning a stale or null company, which would silently skip scoping for that request. Worth noting CompanyMiddleware._get_user_default_company traverses the same cached relation and has the same characteristic.

Tests in horilla_api/tests/test_tenant_scoping.py cover the resolver, the authentication hook, the settings wiring, and two symmetric end-to-end assertions -- each company sees its own rows and not the other's, checked in both directions so a filter pinned to one company would also fail. Verified that reverting the settings change makes them fail.

The fixture grants employee.view_employee to both users deliberately: without it EmployeeListAPIView takes its subordinates-only branch and returns nothing, so the assertions would pass on an empty list regardless of scoping. Asserting only that a user sees its own data is the shape of test that cannot detect this, which is why the coverage is written symmetrically.

Scope: this establishes the manager-level default only. Per-viewset get_queryset filtering is still worth adding, since a manager default can be bypassed by _base_manager, entire() or raw SQL. Also open on this surface: token revocation, request throttling, and serializers using fields="__all__".

359 tests pass across horilla_api, base, employee, report, leave, attendance and payroll.

## Description

<!-- What does this PR change, and why? -->

## Checklist

- [ ] **This PR targets `dev/v2.0`, not `2.0`.** GitHub defaults new PRs to `2.0` (the repo default) — change the base branch to `dev/v2.0` before submitting.
- [ ] I've followed the coding conventions in [CONTRIBUTING.md](../CONTRIBUTING.md) (Black + isort, Horilla decorators/`HorillaModel` patterns, etc.)
- [ ] CI (Docker CI + Quality) passes
- [ ] I've linked any related issues

## Related issues

<!-- e.g. Closes #123 -->
