### PR TITLE
Add CODEOWNERS for deployment, tenancy and payroll paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,52 @@
+# Code owners for horilla-hr.
+#
+# A path listed here gets its owner requested automatically on any PR that
+# touches it. Combined with branch protection on dev/v2.0 and 2.0, it means
+# the files that decide how the product is deployed and secured cannot be
+# changed without someone who knows them looking.
+#
+# Syntax: last matching pattern wins, so the specific entries below the
+# default are the ones that take effect.
+#
+# NOTE: to make these reviews *mandatory* rather than merely requested, turn
+# on "Require review from Code Owners" in the branch protection settings for
+# each branch. Listing an owner here alone only requests them.
+
+# Default owner for anything not matched below.
+*                               @horilla-opensource
+
+# --- Deployment and runtime configuration ---
+# Settings decide DEBUG, ALLOWED_HOSTS, the security gate, storage backends
+# and the auth stack. A wrong edit here is a production incident, not a bug.
+/horilla/settings/              @horilla-opensource
+/horilla/observability.py       @horilla-opensource
+/horilla/scheduling.py          @horilla-opensource
+
+# Container and process configuration: how many workers run, which process
+# owns the scheduled jobs, what the entrypoint does on boot.
+/Dockerfile                     @horilla-opensource
+/docker-compose.yml             @horilla-opensource
+/docker-compose.prod.yml        @horilla-opensource
+/docker/                        @horilla-opensource
+
+# --- CI and its own gates ---
+# A PR can otherwise edit the checks that are meant to be gating it.
+/.github/                       @horilla-opensource
+
+# --- Dependencies ---
+# Pins carry CVE rationale inline; a bump can silently reintroduce an
+# advisory or break a transitive constraint.
+/requirements.txt               @horilla-opensource
+
+# --- Multi-tenancy and authentication ---
+# Company scoping is enforced in a small number of places. Everything else
+# in the product inherits its correctness from these files.
+/base/horilla_company_manager.py  @horilla-opensource
+/base/middleware.py               @horilla-opensource
+/base/auth_backends.py            @horilla-opensource
+/horilla_api/authentication.py    @horilla-opensource
+/horilla/decorators.py            @horilla-opensource
+
+# --- Payroll ---
+# Money. Changes here have legal consequences for employees.
+/payroll/                       @horilla-opensource

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,16 +1,21 @@
 # Code owners for horilla-hr.
 #
-# A path listed here gets its owner requested automatically on any PR that
-# touches it. Combined with branch protection on dev/v2.0 and 2.0, it means
-# the files that decide how the product is deployed and secured cannot be
-# changed without someone who knows them looking.
+# A path listed here gets its owner requested automatically as a reviewer on
+# any PR that touches it -- a routing hint, so changes to the files that
+# decide how the product is deployed and secured reach someone who knows
+# them.
 #
 # Syntax: last matching pattern wins, so the specific entries below the
 # default are the ones that take effect.
 #
-# NOTE: to make these reviews *mandatory* rather than merely requested, turn
-# on "Require review from Code Owners" in the branch protection settings for
-# each branch. Listing an owner here alone only requests them.
+# This file ENFORCES NOTHING on its own. It requests reviewers; it cannot
+# block a merge. Two separate settings would be needed for that, neither of
+# which is currently enabled on this repository:
+#
+#   1. branch protection on dev/v2.0 and 2.0, and
+#   2. "Require review from Code Owners" within it.
+#
+# So treat a request generated from this file as a prompt, not a gate.
 
 # Default owner for anything not matched below.
 *                               @horilla-opensource


### PR DESCRIPTION
Completes the branch-protection work. Protection is now active on `dev/v2.0` and `2.0` — a PR is required, seven checks must pass, and branches must be up to date. This adds *who should look* at the changes that matter most.

## Paths covered

| Path | Why |
|---|---|
| `horilla/settings/` | `DEBUG`, `ALLOWED_HOSTS`, the production security gate, storage backends, the auth stack |
| `Dockerfile`, both compose files, `docker/` | Worker counts, which process owns scheduled jobs, what the entrypoint runs on boot |
| `.github/` | Otherwise a PR can edit the checks meant to be gating it |
| `requirements.txt` | Pins carry CVE rationale inline; a bump can reintroduce an advisory or break a transitive constraint |
| `base/horilla_company_manager.py`, `base/middleware.py`, `base/auth_backends.py`, `horilla_api/authentication.py`, `horilla/decorators.py` | Company scoping and authorisation are enforced in a small number of places; the rest of the product inherits correctness from these |
| `payroll/` | Money, with legal consequences for employees |

The tenancy list is drawn from where the recent scoping work actually landed — those five files are the ones that decide whether isolation holds.

## Two things worth knowing

**This only *requests* reviewers.** Making them mandatory needs **"Require review from Code Owners"** enabled in branch protection, per branch. The file header says so, so nobody assumes it is enforced when it is not.

**`enforce_admins` is currently off** on both branches. Admins can still merge without the checks passing — a deliberate escape hatch rather than an oversight. If you want the gate to bind everyone, that is one API call or a checkbox, and I would recommend it with a documented break-glass procedure instead.

Owner handle verified as an existing account with push access, which CODEOWNERS requires to route a review request.