### PR TITLE
Add ruff, scoped to rules the codebase passes today

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -36,13 +36,20 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install "black==24.4.2" "isort==5.13.2"
+          pip install "black==24.4.2" "isort==5.13.2" "ruff==0.16.5"
 
       - name: Ensure local_settings stub exists
         run: |
           if [ ! -f horilla/settings/local_settings.py ]; then
             printf '%s\n' '# Ephemeral for CI' > horilla/settings/local_settings.py
           fi
+
+      # Ruff runs over the whole repo, unlike the Black/isort steps below --
+      # its enabled rule set is scoped to defects that the codebase already
+      # passes (see pyproject.toml), so it gates everything without the
+      # reformat-the-world diff a full style pass would need.
+      - name: Ruff (whole repo)
+        run: ruff check .
 
       - name: Black (settings + urls)
         run: black --check horilla/settings horilla/urls.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,14 @@ repos:
         exclude: ^.*/migrations/
       - id: trailing-whitespace
         exclude: ^.*/migrations/
+  # Ruff first: it catches defects, and there is no point reformatting code
+  # that has an undefined name in it.
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.5
+    hooks:
+      - id: ruff
+        args: [--fix]
+
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.4.2
     hooks:

--- a/base/tests/test_scheduling.py
+++ b/base/tests/test_scheduling.py
@@ -203,3 +203,71 @@ class DeploymentWiringTests(SimpleTestCase):
             "biometric/views.py starts a scheduler outside a function",
         )
         self.assertIn("register_job(", source)
+
+
+class RuffConfigTests(SimpleTestCase):
+    """
+    Ruff's rule set is deliberately narrow. The full E,F,B set reports ~4,500
+    findings here, dominated by line-length and star-import usage -- a gate
+    that fails on 4,500 issues gets disabled rather than fixed, which is the
+    same trap .coveragerc records about the coverage floor.
+
+    So the enabled rules are ones the codebase passes today, and the config
+    documents the follow-up set. These tests guard both halves: that the gate
+    is wired, and that the follow-up list has not been quietly deleted
+    instead of worked through.
+    """
+
+    def _pyproject(self):
+        from pathlib import Path
+
+        from django.conf import settings
+
+        return (Path(settings.BASE_DIR) / "pyproject.toml").read_text(
+            encoding="utf-8"
+        )
+
+    def test_ruff_is_configured(self):
+        body = self._pyproject()
+        self.assertIn("[tool.ruff]", body)
+        self.assertIn("[tool.ruff.lint]", body)
+
+    def test_migrations_and_vendored_code_are_excluded(self):
+        """Migrations are generated, and notifications is vendored."""
+        body = self._pyproject()
+        self.assertIn("*/migrations/*", body)
+        self.assertIn("notifications", body)
+
+    def test_ci_runs_ruff_over_the_whole_repo(self):
+        """Black and isort cover two paths; ruff has to cover everything or
+        it adds nothing the pre-commit hook did not already."""
+        from pathlib import Path
+
+        from django.conf import settings
+
+        workflow = (
+            Path(settings.BASE_DIR) / ".github/workflows/quality.yml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("ruff check .", workflow)
+        # Pinned, like the other two linters, so a new release cannot turn a
+        # green branch red without a deliberate bump.
+        self.assertIn('"ruff==', workflow)
+
+    def test_precommit_runs_ruff(self):
+        from pathlib import Path
+
+        from django.conf import settings
+
+        config = (
+            Path(settings.BASE_DIR) / ".pre-commit-config.yaml"
+        ).read_text(encoding="utf-8")
+        self.assertIn("ruff-pre-commit", config)
+
+    def test_followup_rules_are_still_documented(self):
+        """The 93 known defects are listed in the config as the next pass.
+        If someone widens the rule set they should be removing entries from
+        that list, not the list itself."""
+        body = self._pyproject()
+        for rule in ("F811", "B023", "F821", "E722", "B006"):
+            with self.subTest(rule=rule):
+                self.assertIn(rule, body)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,71 @@
+# Ruff configuration.
+#
+# Scope note: running ruff's full E,F,B rule set over this codebase reports
+# ~4,500 findings, dominated by E501 line-too-long (1,797) and F405
+# star-import usage (1,088). A gate that fails on 4,500 issues gets disabled
+# rather than fixed, which is worse than no gate -- the same reasoning
+# .coveragerc records about the coverage floor.
+#
+# So this starts from the rules that catch *bugs* rather than style, all of
+# which the codebase can pass today. Widen it by moving rules up from the
+# "not yet enabled" list below as they get cleaned, never by loosening it to
+# make a build pass.
+
+[tool.ruff]
+line-length = 88
+target-version = "py312"
+extend-exclude = [
+    "venv",
+    "staticfiles",
+    "*/migrations/*",
+    # Vendored django-notifications, carrying upstream's own style.
+    "notifications",
+]
+
+[tool.ruff.lint]
+select = [
+    "F502",  # percent-format with a dict where a tuple is expected
+    "F602",  # `in` on a str where a tuple was meant
+    "F632",  # `is` comparison against a literal
+    "F701",  # break outside a loop
+    "F702",  # continue outside a loop
+    "F706",  # return outside a function
+    "F707",  # except: not last
+    "E902",  # I/O or tokenize error
+]
+
+# Not yet enabled. The first block below is the immediate follow-up: 93
+# findings that are genuine defects rather than style, small enough to fix in
+# one pass. Enabling them here before that pass would ship a red gate.
+#
+#   F811  redefined-while-unused  51  -- duplicate imports, but also
+#                                        duplicate methods where the first is
+#                                        dead code (see leave/forms.py:835,
+#                                        where a stray `def save` sits inside
+#                                        clean() and orphans its validation)
+#   B023  closure over loop var    9  -- late-binding; the closure sees the
+#                                        last value, not the one it was made
+#                                        with
+#   F601  repeated dict key        7  -- one value silently wins
+#   F402  import shadowed by loop  5
+#   F821  undefined name           5  -- NameError at runtime
+#   E721  type comparison          4
+#   E101  mixed tabs and spaces    3
+#   B035  static key in dict comp  3
+#   B012  return inside finally    2  -- silences the exception
+#   B026  star-arg after keyword   2
+#   F823  referenced before assign 2
+#
+# Then, in rough order of value per effort:
+#   E722  bare except            148  -- swallows KeyboardInterrupt/SystemExit
+#   B006  mutable default arg     80
+#   B904  raise without from      71  -- loses the original traceback
+#   F841  unused variable        168
+#   F401  unused import          500  -- mostly auto-fixable
+#   E712/E711  == True / == None  71
+#   E501  line too long        1,797  -- needs a formatting decision first
+#   F403/F405 star imports     1,141  -- needs real import work
+
+[tool.ruff.lint.per-file-ignores]
+# Settings modules legitimately re-export via star imports.
+"horilla/settings/*.py" = ["F403", "F405"]


### PR DESCRIPTION
There was **no linter or type checker in this repo at all**, and CI's formatting check covered **two paths out of ~990 files**. Pre-commit covered more but is opt-in — and this repo has not installed the hook, so its own committed code fails `black --check`.

## The scope decision, and why it matters

Running ruff's full `E,F,B` set here reports **~4,500 findings**:

| Rule | Count |
|---|---|
| `E501` line-too-long | 1,797 |
| `F405` star-import usage | 1,088 |
| `F401` unused import | 500 |
| `F841` unused variable | 168 |
| `E722` bare except | 148 |
| `B006` mutable default arg | 80 |

**A gate that fails on 4,500 issues gets disabled rather than fixed** — the same trap `.coveragerc` already records about the coverage floor. So this enables only rules the codebase passes today, and documents the rest as a staged follow-up in `pyproject.toml`. Widen it by removing entries from that list, never by loosening the gate to make a build pass.

## Wired in two places

- **`ruff check .` in the quality workflow** — over the *whole repo*, not two paths. Pinned to `0.16.5` like black and isort, so a new ruff release can't turn a green branch red without a deliberate bump.
- **A `ruff-pre-commit` hook ahead of black** — reformatting code that has an undefined name in it is pointless.

## What the narrow set already found

The config records **93 findings that are genuine defects rather than style**, small enough for one follow-up pass. The notable ones:

**`leave/forms.py:835` — a shipped bug.** A stray `def save(self, commit=True):` sits *inside* `clean()`, orphaning that method's `"Employee not chosen"` validation and shadowing the real `save()` five lines below. Confirmed by AST: `LeaveAllocationBulkForm` defines `save()` twice, at lines 835 and 840. **That validation never runs today.**

- **`F821` (5)** — undefined names, i.e. `NameError` on any path that reaches them, including `biometric/views.py:1897` and `helpdesk/views.py:1476`
- **`B023` (9)** — closures over loop variables in `pms/signals.py` and `horilla_automations/signals.py`; each sees the *last* value, not the one it was created with
- **`B012` (2)** — `return` inside `finally`, which silences the exception
- **`F601` (7)** — repeated dict keys, where one value silently wins

**Deliberately not fixed here.** This PR is the gate; mixing 14 behaviour changes into it would make both halves harder to review. They're the immediate follow-up.

## Verification

- `ruff check .` passes
- **374 tests pass** across `base`, `attendance`, `leave`, `payroll`, `report`, `horilla_api`
- `pyproject.toml` contains only `[tool]` — no `[project]` or `[build-system]`, so pip and setuptools ignore it
- `black --check` still passes; `line-length = 88` matches Black's default deliberately, so the two can't disagree

`RuffConfigTests` assert the gate is wired in both places, that migrations and the vendored `notifications` app stay excluded, and that the follow-up rule list hasn't been deleted instead of worked through.