### PR TITLE
Fix the permission check and creator lookup in claim approval

### DIFF
--- a/helpdesk/tests/test_claim_request_access.py
+++ b/helpdesk/tests/test_claim_request_access.py
@@ -1,0 +1,126 @@
+"""Access-control tests for the claim-request approval view.
+
+These exercise the branch where the caller holds neither
+`helpdesk.change_claimrequest` nor `helpdesk.change_ticket` and is not a
+department manager for the ticket. That is the only branch the permission
+check in `approve_claim_request` actually has to decide -- either permission
+short-circuits the `or` chain before it -- so it is also the branch a manual
+smoke test with an admin account never reaches.
+"""
+
+from django.contrib.auth.models import Permission
+from django.test import TestCase
+from django.urls import reverse
+
+from helpdesk.models import ClaimRequest, Ticket, TicketType
+from horilla.testkit import make_company, make_employee, make_user
+
+
+class ClaimRequestAccessControlTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.company = make_company("Acme")
+        cls.ticket_type = TicketType.objects.create(
+            title="IT Support", type="service_request", prefix="ITS"
+        )
+
+        cls.owner_user = make_user("claim-owner")
+        cls.owner = make_employee(
+            company=cls.company,
+            email="claim-owner@test.horilla",
+            first_name="Olive",
+            last_name="Owner",
+            user=cls.owner_user,
+        )
+
+        cls.claimant_user = make_user("claim-claimant")
+        cls.claimant = make_employee(
+            company=cls.company,
+            email="claim-claimant@test.horilla",
+            first_name="Cody",
+            last_name="Claimant",
+            user=cls.claimant_user,
+        )
+
+        # No helpdesk permissions, not a department manager, not assigned to
+        # the ticket, and not its owner.
+        cls.outsider_user = make_user("claim-outsider")
+        cls.outsider = make_employee(
+            company=cls.company,
+            email="claim-outsider@test.horilla",
+            first_name="Ivan",
+            last_name="Outsider",
+            user=cls.outsider_user,
+        )
+
+        cls.ticket = Ticket.objects.create(
+            title="Laptop will not boot",
+            employee_id=cls.owner,
+            ticket_type=cls.ticket_type,
+            description="Dead on power-on.",
+            priority="medium",
+            assigning_type="individual",
+            raised_on="1",
+        )
+        cls.claim = ClaimRequest.objects.create(
+            ticket_id=cls.ticket, employee_id=cls.claimant
+        )
+
+    def setUp(self):
+        self.url = reverse(
+            "approve-claim-request", kwargs={"req_id": self.claim.pk}
+        )
+
+    def test_unrelated_caller_cannot_approve_a_claim_request(self):
+        """Someone with no relationship to the ticket must be refused.
+
+        This is refused by the ``ticket_owner_can_enter`` decorator rather
+        than by the view's own check, so it passes even with that check
+        broken; it is here to pin the outer guard in place.
+        """
+        self.client.force_login(self.outsider_user)
+
+        self.client.get(self.url, {"approve": "True"})
+
+        self.assertNotIn(
+            self.claimant,
+            self.ticket.assigned_to.all(),
+            "a caller unrelated to the ticket approved a claim request",
+        )
+
+    def test_ticket_owner_without_helpdesk_permission_cannot_approve(self):
+        """The reachable case the view's own check exists to decide.
+
+        The ticket's own raiser satisfies ``ticket_owner_can_enter`` (it
+        admits ``request.user.employee_get == ticket.employee_id``), so the
+        decorator lets them in and the view's permission check is the only
+        thing left standing between them and approving a claim. They hold no
+        helpdesk permission and are not a department manager, so it must
+        refuse -- approving adds the claimant to ``ticket.assigned_to``.
+        """
+        self.client.force_login(self.owner_user)
+
+        self.client.get(self.url, {"approve": "True"})
+
+        self.assertNotIn(
+            self.claimant,
+            self.ticket.assigned_to.all(),
+            "the ticket owner approved a claim request without permission",
+        )
+
+    def test_caller_with_change_ticket_permission_can_approve(self):
+        """The check must still let a genuinely authorised caller through."""
+        self.outsider_user.user_permissions.add(
+            Permission.objects.get(
+                codename="change_ticket", content_type__app_label="helpdesk"
+            )
+        )
+        self.client.force_login(self.outsider_user)
+
+        self.client.get(self.url, {"approve": "True"})
+
+        self.assertIn(
+            self.claimant,
+            self.ticket.assigned_to.all(),
+            "an authorised caller was blocked from approving",
+        )

--- a/helpdesk/views.py
+++ b/helpdesk/views.py
@@ -1461,7 +1461,7 @@ def claim_ticket(request, id):
 
 
 @login_required
-@ticket_owner_can_enter(perm="helpdesk.change_ticket", model=Ticket)
+@ticket_owner_can_enter(perm="helpdesk.change_ticket", model=ClaimRequest)
 def approve_claim_request(request, req_id):
     """
     Function for approve claim request and send notifications to the responsibles.
@@ -1470,19 +1470,20 @@ def approve_claim_request(request, req_id):
     if not claim_request:
         return HttpResponse("Invalid claim request", status=404)
 
+    ticket = claim_request.ticket_id
+    employee = claim_request.employee_id
+
     if not (
         request.user.has_perm("helpdesk.change_claimrequest")
         or request.user.has_perm("helpdesk.change_ticket")
         or is_department_manager(request, ticket)
     ):
-        handle_no_permission(request)
+        return handle_no_permission(request)
 
     approve = strtobool(
         request.GET.get("approve", "False")
     )  # Safely convert to boolean
 
-    ticket = claim_request.ticket_id
-    employee = claim_request.employee_id
     refresh = False
     if approve:
         # message
@@ -1505,8 +1506,13 @@ def approve_claim_request(request, req_id):
                 )
             except Exception as e:
                 logger.error(e)
-            if not ticket.employee_id == ticket.created_by.employee_get:
-                for emp in [ticket.created_by.employee_get, ticket.employee_id]:
+            # created_by is null=True with on_delete=SET_NULL, so it is None
+            # for tickets not created through a request (fixtures, imports,
+            # the shell) and for any ticket whose creator has since been
+            # deleted. Notify the raiser alone in that case.
+            raiser = ticket.created_by.employee_get if ticket.created_by else None
+            if raiser is not None and raiser != ticket.employee_id:
+                for emp in [raiser, ticket.employee_id]:
                     try:
                         notify.send(
                             request.user.employee_get,


### PR DESCRIPTION
`approve_claim_request` has four defects in one code path, three of them inside its own permission check.

## 1. The check raised instead of deciding

```python
if not (
    request.user.has_perm("helpdesk.change_claimrequest")
    or request.user.has_perm("helpdesk.change_ticket")
    or is_department_manager(request, ticket)   # ← ticket assigned 11 lines later
):
```

`UnboundLocalError: cannot access local variable 'ticket'`.

**This is reachable.** `ticket_owner_can_enter` admits the ticket's own raiser (`request.user.employee_get == ticket.employee_id`), so a raiser holding no helpdesk permission passes the decorator and the view's check is the only guard left standing — and it crashes rather than refusing. Confirmed by test against the unfixed code:

```
File "helpdesk/views.py", line 1476, in approve_claim_request
    or is_department_manager(request, ticket)
UnboundLocalError: cannot access local variable 'ticket' where it is not associated with a value
```

Fixed by moving the `ticket`/`employee` assignments above the check — the same order the equivalent check in `ticket_claim_requests` already uses.

## 2. `handle_no_permission` was called but not returned

```python
    handle_no_permission(request)   # response built, then discarded
```

The helper builds a response; discarding it lets execution continue into the approval body, which adds the claimant to `ticket.assigned_to`. **Every one of the eight other `handle_no_permission` call sites in this module returns it** — this was the only one that did not.

## 3. The decorator resolved the wrong model

```python
@ticket_owner_can_enter(perm="helpdesk.change_ticket", model=Ticket)
def approve_claim_request(request, req_id):
```

The URL supplies `req_id`, a **ClaimRequest** primary key, so the decorator ran `Ticket.objects.get(id=<claim pk>)` — an unrelated ticket wherever the ids collide, and the bare `except` in `helpdesk/decorators.py` otherwise. `ClaimRequest` has the `employee_id` the decorator needs, so declaring it correctly is sufficient.

## 4. Unguarded `created_by` dereference

```python
if not ticket.employee_id == ticket.created_by.employee_get:
```

`created_by` is `null=True` with `on_delete=SET_NULL`, so it is `None` for tickets not created through a request (fixtures, imports, the shell) and for any ticket whose creator has since been deleted. Approving then raised `AttributeError: 'NoneType' object has no attribute 'employee_get'` **for a fully authorised caller.**

Guarded. The raiser still receives their own notification from the unconditional block below, so only the extra creator notification is skipped when there is no creator — no change to who gets notified otherwise.

## Tests

`helpdesk/tests/test_claim_request_access.py` covers the three outcomes:

| Case | Unfixed | Fixed |
|---|---|---|
| unrelated caller refused | passes (decorator refuses) | passes |
| ticket raiser without permission refused | **`UnboundLocalError`** | passes |
| caller with `change_ticket` still approves | **`AttributeError`** | passes |

Written and run against the unfixed code first. The first case passes either way and is there to pin the outer guard; the third test is what surfaced defect 4, which I had not spotted by reading.

**378 tests pass** across `helpdesk`, `base`, `attendance`, `leave`, `payroll`, `report`, `horilla_api`. `ruff check .` and `black --check` both clean.

## Not included

`helpdesk/views.py:403` — `faq_delete` shadows the module-level `messages` import with a local `message`, which ruff reports as `F823`. Real, but a different view; it belongs with the wider ruff follow-up rather than here.

`view_ticket_document` and `delete_ticket_document` have the same decorator/id mismatch as defect 3 (`doc_id` is an `Attachment` pk checked against `Ticket`). Unlike defect 3 those fail *closed* — `Attachment` has no `employee_id`, so the decorator's bare `except` redirects — making them a usability bug rather than a permission one. Worth fixing, separately.