### PR TITLE
[FIX] HORILLA: Correct the stale HORILLA_REQUIRE_SCHEDULER note in .e…

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -63,8 +63,10 @@ REDIS_URL=redis://:change-me-redis-password@redis:6379/0
 # GUNICORN_LOG_LEVEL=info
 # GUNICORN_RELOAD=false
 
-# /ready/ returns 503 until run_scheduler has registered jobs. Production
-# compose sets this; leave unset/false if you are not running that process.
+# /ready/ returns 503 until run_scheduler has registered jobs. Opt-in, and off
+# by default: a stopped scheduler delays background jobs, while a 503 here can
+# remove web from the load balancer and stop it serving requests entirely.
+# Enable only where a failing readiness probe will not do that.
 # HORILLA_REQUIRE_SCHEDULER=0
 
 # Optional AWS S3 media (see horilla/settings/addons.py)


### PR DESCRIPTION
…nv.dist

The comment says "Production compose sets this", which stopped being true before #1205 merged: HORILLA_REQUIRE_SCHEDULER=1 was dropped from docker-compose.prod.yml, which now has no occurrence of it. Anyone reading .env.dist would expect readiness to already gate on the scheduler in production, and it does not.

Replaces it with what the flag actually does and why it is off by default -- matching the wording already in horilla/urls.py and docker/README.md, which were both updated at merge time.

Comment-only; the HORILLA_REQUIRE_SCHEDULER=0 line itself is unchanged and still commented out.

## Description

<!-- What does this PR change, and why? -->

## Checklist

- [ ] **This PR targets `dev/v2.0`, not `2.0`.** GitHub defaults new PRs to `2.0` (the repo default) — change the base branch to `dev/v2.0` before submitting.
- [ ] I've followed the coding conventions in [CONTRIBUTING.md](../CONTRIBUTING.md) (Black + isort, Horilla decorators/`HorillaModel` patterns, etc.)
- [ ] CI (Docker CI + Quality) passes
- [ ] I've linked any related issues

## Related issues

<!-- e.g. Closes #123 -->
