### PR TITLE
[FIX] BASE: Restore the export-permission seed and dedupe data migrat…

### DIFF
--- a/base/migrations/0016_seed_default_export_permission.py
+++ b/base/migrations/0016_seed_default_export_permission.py
@@ -1,0 +1,98 @@
+"""
+Seed the "Default Export Access" rows, and collapse any duplicates.
+
+Migration 0015 added the uniqueness constraints but the two data steps that
+belong with them were lost when this change was ported: the per-company seed
+and the dedupe that has to run *before* a uniqueness constraint can be
+applied to a table that may already contain duplicates.
+
+Without the seed, `has_export_access` falls back to "no row means enabled",
+which is the permissive-by-absence behaviour 0015 set out to remove -- the
+setting is invisible in the UI until an admin happens to toggle it. The
+`base.tests.test_export_permission_seeding` suite asserts the seeded rows and
+has been failing on this branch since 0015 landed.
+
+Dedupe runs first here for installs that predate 0015 and could not have had
+the constraints enforced yet. Where 0015 already applied cleanly it is a no-op.
+"""
+
+from django.db import migrations
+
+
+def dedupe(apps, schema_editor):
+    """
+    Collapse duplicate rows, keeping the most restrictive per company.
+
+    Every reader does .filter(company_id=...).first(), so a duplicate row
+    silently decided the setting by insertion order. If an admin ever
+    disabled export access, honour that rather than letting a stray enabled
+    row re-open it.
+    """
+    DefaultExportPermission = apps.get_model("base", "DefaultExportPermission")
+    seen = {}
+    for row in DefaultExportPermission.objects.order_by("id"):
+        key = row.company_id_id
+        if key not in seen:
+            seen[key] = row
+            continue
+        keeper = seen[key]
+        if not row.is_enabled and keeper.is_enabled:
+            keeper.is_enabled = False
+            keeper.save(update_fields=["is_enabled"])
+        row.delete()
+
+
+def seed_rows(apps, schema_editor):
+    """
+    Give every company an explicit row, preserving today's behaviour.
+
+    Flipping the default to deny would silently remove export access from
+    installs relying on it, with no UI hint why. The point is to make the
+    value visible and deliberate, not to change it.
+    """
+    Company = apps.get_model("base", "Company")
+    DefaultExportPermission = apps.get_model("base", "DefaultExportPermission")
+
+    existing = set(DefaultExportPermission.objects.values_list("company_id", flat=True))
+    missing = [
+        cid
+        for cid in Company.objects.values_list("id", flat=True)
+        if cid not in existing
+    ]
+    DefaultExportPermission.objects.bulk_create(
+        [
+            DefaultExportPermission(company_id_id=cid, is_enabled=True)
+            for cid in missing
+        ],
+        batch_size=500,
+    )
+
+    # company_id=None is what has_export_access() looks up when the session
+    # scope is "All companies", so it needs a row of its own.
+    if None not in existing:
+        DefaultExportPermission.objects.create(company_id=None, is_enabled=True)
+
+
+def noop(apps, schema_editor):
+    """
+    Deliberately a no-op.
+
+    Removing the rows would restore the implicit default rather than any
+    prior explicit state, and nothing records which rows this migration
+    created versus which an admin had already set.
+    """
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        (
+            "base",
+            "0015_defaultexportpermission_unique_default_export_permission_per_company_and_more",
+        ),
+    ]
+
+    operations = [
+        migrations.RunPython(dedupe, noop),
+        migrations.RunPython(seed_rows, noop),
+    ]


### PR DESCRIPTION
…ions

Migration 0015 added the uniqueness constraints for Default Export Access, but the two RunPython steps that belong with them were lost when the change was ported to this branch: the per-company seed, and the dedupe that must run before a uniqueness constraint is applied to a table that may already hold duplicates.

Consequences on this branch:

- base.tests.test_export_permission_seeding has failed since 0015 landed (test_migration_seeded_the_null_company_row, and test_duplicate_null_company_row_is_rejected -- the latter only passes when the seeded row is already there to collide with).
- has_export_access falls back to "no row means enabled", which is exactly the permissive-by-absence behaviour 0015 set out to replace. The setting stays invisible in the UI until an admin happens to toggle it.
- 0015 would fail to apply on any install that already had duplicate rows, since nothing collapsed them first.

0016 restores both steps rather than editing 0015, which has already shipped. Dedupe runs first, keeping the most restrictive row per company so a disabled setting is never re-opened by a stray enabled one; where 0015 applied cleanly it is a no-op. The seed preserves current behaviour (enabled) -- the point is to make the value explicit, not to change it.

Verified on PostgreSQL against a fresh database: the two failing tests pass, makemigrations --check reports no drift, and the full CI label set is 542 tests OK.

## Description

<!-- What does this PR change, and why? -->

## Checklist

- [ ] **This PR targets `dev/v2.0`, not `2.0`.** GitHub defaults new PRs to `2.0` (the repo default) — change the base branch to `dev/v2.0` before submitting.
- [ ] I've followed the coding conventions in [CONTRIBUTING.md](../CONTRIBUTING.md) (Black + isort, Horilla decorators/`HorillaModel` patterns, etc.)
- [ ] CI (Docker CI + Quality) passes
- [ ] I've linked any related issues

## Related issues

<!-- e.g. Closes #123 -->
