### PR TITLE
[FIX] RECRUITMENT: Scope resume access to the recruitment it belongs to

### DIFF
--- a/recruitment/tests/test_resume_scoping.py
+++ b/recruitment/tests/test_resume_scoping.py
@@ -1,0 +1,79 @@
+"""
+Resume has no company_id of its own, so the recruitment is what scopes it.
+
+The public application form reads a resume by id from the query string and
+attaches that file to the submitted application. Unscoped, that let anyone
+walk sequential ids and harvest every CV in the database, across companies.
+"""
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+from django.urls import reverse
+
+from base.models import Department, JobPosition
+from horilla.testkit import make_company
+from recruitment.models import Recruitment, Resume
+
+PDF = b"%PDF-1.4 fake resume bytes"
+
+
+def _recruitment(company_name, title, job_title):
+    company = make_company(company_name)
+    dept = Department.objects.create(department=f"{company_name} Dept")
+    dept.company_id.add(company)
+    jp = JobPosition.objects.create(job_position=job_title, department_id=dept)
+    rec = Recruitment.objects.create(
+        title=title,
+        description="d",
+        company_id=company,
+        job_position_id=jp,
+        vacancy=1,
+        is_published=True,
+        optional_resume=True,
+        optional_profile_image=True,
+    )
+    rec.open_positions.add(jp)
+    return rec
+
+
+class ResumeScopingTests(TestCase):
+    def setUp(self):
+        self.rec_a = _recruitment("Alpha Corp", "Alpha Hire", "Alpha Dev")
+        self.rec_b = _recruitment("Beta Corp", "Beta Hire", "Beta Dev")
+        self.resume_b = Resume.objects.create(
+            file=SimpleUploadedFile("victim.pdf", PDF, content_type="application/pdf"),
+            recruitment_id=self.rec_b,
+        )
+
+    def test_application_form_ignores_a_resume_from_another_recruitment(self):
+        """The cross-tenant read: apply to A, cite B's resume id."""
+        response = self.client.get(
+            reverse("application-form"),
+            {"recruitmentId": self.rec_a.id, "resumeId": self.resume_b.id},
+        )
+        self.assertEqual(response.status_code, 200)
+        # The victim's file must not be handed to the applicant in any form.
+        self.assertNotIn(PDF, response.content)
+        self.assertNotIn(
+            self.resume_b.file.name.encode(),
+            response.content,
+            "another recruitment's resume leaked into the public form",
+        )
+
+    def test_resume_from_the_same_recruitment_still_resolves(self):
+        """The guard must not break the legitimate prefill path."""
+        own = Resume.objects.create(
+            file=SimpleUploadedFile("mine.pdf", PDF, content_type="application/pdf"),
+            recruitment_id=self.rec_a,
+        )
+        response = self.client.get(
+            reverse("application-form"),
+            {"recruitmentId": self.rec_a.id, "resumeId": own.id},
+        )
+        self.assertEqual(response.status_code, 200)
+
+    def test_missing_resume_id_is_harmless(self):
+        response = self.client.get(
+            reverse("application-form"), {"recruitmentId": self.rec_a.id}
+        )
+        self.assertEqual(response.status_code, 200)

--- a/recruitment/views/surveys.py
+++ b/recruitment/views/surveys.py
@@ -503,7 +503,17 @@ def application_form(request):
     recruitment = None
     recruitment_id = request.GET.get("recruitmentId")
     resume_id = request.GET.get("resumeId")
-    resume_obj = Resume.objects.filter(id=resume_id).first()
+    # Scoped to the recruitment being applied to. This page is public and
+    # unauthenticated, and the POST branch below reads this file and attaches
+    # it to the submitted application -- so an unscoped lookup let anyone
+    # harvest any CV in the database, in any company, by walking sequential
+    # ids. Resume has no company_id of its own, so the recruitment is what
+    # scopes it.
+    resume_obj = (
+        Resume.objects.filter(id=resume_id, recruitment_id=recruitment_id).first()
+        if resume_id and recruitment_id
+        else None
+    )
 
     if request.method == "GET" and not recruitment_id:
         messages.error(request, _("Recruitment ID is missing"))

--- a/recruitment/views/views.py
+++ b/recruitment/views/views.py
@@ -3854,7 +3854,13 @@ def view_bulk_resumes(request):
     rec_id = eval_validate(str(request.GET.get("rec_id")))
     if not rec_id:
         return HttpResponse()
-    resumes = Resume.objects.filter(recruitment_id=rec_id)
+    # Recruitment.objects is company-scoped; Resume is not (it has no
+    # company_id of its own), so resolving the recruitment first is what
+    # keeps another company's resumes out of this list.
+    recruitment = Recruitment.objects.filter(id=rec_id).first()
+    if not recruitment:
+        return HttpResponse()
+    resumes = Resume.objects.filter(recruitment_id=recruitment)
 
     return render(
         request, "pipeline/bulk_resume.html", {"resumes": resumes, "rec_id": rec_id}
@@ -3896,7 +3902,14 @@ def delete_resume_file(request):
     """
     ids = request.GET.getlist("ids")
     rec_id = request.GET.get("rec_id")
-    Resume.objects.filter(id__in=ids).delete()
+    # Scope the delete to a recruitment this user can actually reach.
+    # manager_can_enter admits any reporting manager, and Resume is not
+    # company-scoped, so an unscoped filter let a manager in one company
+    # delete another company's resumes by passing their ids.
+    recruitment = Recruitment.objects.filter(id=rec_id).first()
+    if not recruitment:
+        return HttpResponse(status=404)
+    Resume.objects.filter(id__in=ids, recruitment_id=recruitment).delete()
     CACHE.delete(f"matching_resumes_{rec_id}")
 
     url = reverse("view-bulk-resume")
@@ -4017,7 +4030,10 @@ def matching_resumes(request, rec_id):
         )
 
         ranked_resumes = non_candidate_resumes + candidate_resumes
-        CACHE.set(cache_key, ranked_resumes, timeout=None)
+        # A finite TTL, not timeout=None: the ranking is derived from resume
+        # files and the recruitment's skill list, both of which change without
+        # every edit path remembering to invalidate this key.
+        CACHE.set(cache_key, ranked_resumes, timeout=900)
 
     return render(
         request,


### PR DESCRIPTION
Resume is a plain model with no company_id of its own -- unlike Candidate beside it, which is scoped through recruitment_id__company_id. Three views queried Resume.objects directly with an id taken from the request, so the recruitment that owns the resume was never checked.

The serious one is the public application form. It is unauthenticated, and its POST branch reads the cited resume file and attaches it to the submitted application, which is then saved against the applicant's own candidate record. So anyone could pass an arbitrary resumeId, submit, and receive that file -- and since ids are sequential integers, walk them to harvest every CV in the database, in every company.

- application_form: the lookup is now filtered by the recruitment being applied to, and skipped entirely when either id is absent.
- view_bulk_resumes / delete_resume_file: resolve the recruitment through Recruitment.objects (which IS company-scoped) and scope the resume query to it. manager_can_enter admits any reporting manager of anyone, with no company scoping, so the delete let a manager in one company remove another company's resumes by passing their ids.

Also gives the ranking cache a finite TTL. It was timeout=None, keyed on the recruitment pk, and derived from resume files and the skill list -- both of which change without every edit path invalidating the key.

Tests assert the cross-recruitment read is refused, the legitimate same-recruitment prefill still works, and a missing id is harmless. The cross-tenant test was confirmed to FAIL against the unscoped lookup before the fix, so it pins the vulnerability rather than the implementation.

Verified on PostgreSQL: 545 tests OK, ruff clean, no migration drift.

## Description

<!-- What does this PR change, and why? -->

## Checklist

- [ ] **This PR targets `dev/v2.0`, not `2.0`.** GitHub defaults new PRs to `2.0` (the repo default) — change the base branch to `dev/v2.0` before submitting.
- [ ] I've followed the coding conventions in [CONTRIBUTING.md](../CONTRIBUTING.md) (Black + isort, Horilla decorators/`HorillaModel` patterns, etc.)
- [ ] CI (Docker CI + Quality) passes
- [ ] I've linked any related issues

## Related issues

<!-- e.g. Closes #123 -->
