### PR TITLE
[UPDT] HORILLA: Bump version to 2.1.0

### DIFF
--- a/horilla/__version__.py
+++ b/horilla/__version__.py
@@ -5,4 +5,4 @@ this string matches the git tag being built, so a mismatch fails the release
 rather than shipping an image whose label disagrees with its tag.
 """
 
-__version__ = "2.0.0"
+__version__ = "2.1.0"


### PR DESCRIPTION
Prepares the 2.1.0 release. One line changed.

The publish workflow asserts `horilla/__version__.py` matches the tag being built and fails the release on a mismatch, so this must land before `2.1.0` is tagged.

**Why minor and not patch.** The WhatsApp webhook now requires a Meta App Secret before it will accept a delivery, so **message delivery stops for existing WhatsApp installs until an admin sets it**. That is a behaviour change an operator has to act on, and it does not belong in a patch release.

Release readiness on `86efa244` (the current `2.0` head): Unit Tests, Quality, CodeQL and Docker CI all green.

After this merges, tagging `2.1.0` triggers the Docker publish, which takes `latest`, the `2.1` alias, and mirrors to the deprecated `horilla/horilla` repository.
