### PR TITLE
[FIX] DOCKER: Pin msgpack and setuptools to clear the release image scan

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -115,5 +115,17 @@ tinycss2==1.5.1
 gunicorn==23.0.0
 packaging==26.3
 
+# Transitive, pinned because the release image scan fails on a fixable HIGH
+# and the versions that resolve by default are vulnerable.
+#
+# msgpack arrives via CacheControl. 1.1.2 has an out-of-bounds read that
+# crashes on Unpacker reuse (GHSA-6v7p-g79w-8964); 1.2.1 fixes it.
+msgpack==1.2.2
+# setuptools comes from the base image and is required at runtime by spacy
+# and thinc. 70.3.0 carries a path traversal (CVE-2025-47273), and
+# `pip install --upgrade pip` does not upgrade setuptools, so the image kept
+# the old one. Neither spacy nor thinc caps the version.
+setuptools==84.0.0
+
 # Testing
 coverage>=7.0


### PR DESCRIPTION
The `2.1.0` publish failed its Trivy gate. **The gate was right and no image was published** — it scans before any push, so the `2.1.0` tag currently exists in git with nothing shipped against it. Docker Hub still shows only the August 30 tags.

## What it found

| Package | Vulnerability | Installed | Fixed in | Arrives via |
|---|---|---|---|---|
| `msgpack` | GHSA-6v7p-g79w-8964 — out-of-bounds read, crash on `Unpacker` reuse | 1.1.2 | 1.2.1 | CacheControl |
| `setuptools` | CVE-2025-47273 — path traversal | 70.3.0 | 78.1.1 | base image; runtime requirement of spacy + thinc |

Both transitive, neither pinned in `requirements.txt`, and both have fixes available — which is exactly the case the gate is configured to block on (`ignore-unfixed: true`).

`setuptools` is the more interesting one: it ships in `python:3.12-slim` and `pip install --upgrade pip` does **not** upgrade it, so the image kept whatever the base image carried regardless of what resolves locally.

## The fix

Pin both, following the convention already used for `PyJWT` and `tinycss2` — an explicit pin with a comment saying why it is there, so nobody later "cleans up" a pin that looks redundant.

Checked before pushing: `pip install --dry-run -r requirements.txt` resolves, `pip check` reports no broken requirements, and neither spacy nor thinc caps `setuptools`.

## After this merges

Re-run the Docker Publish workflow for `2.1.0`. The tag does not need to be recreated — it points at `e946ad07`, and this fix will need to be included, so the tag should be moved to the new head after merge.
