### PR TITLE
[FIX] CI: Stop the release scan serving cached results for a stale image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -202,6 +202,14 @@ jobs:
           severity: CRITICAL,HIGH
           exit-code: "1"
           ignore-unfixed: true
+          # The image is always built and scanned under the same fixed tag
+          # (horilla-hr:smoketest), so the action's result cache can serve a
+          # previous run's findings for a different image. That happened on
+          # the 2.1.0 release: the build log shows msgpack 1.2.2 and
+          # setuptools 84.0.0 installed, and the scan still reported the
+          # 1.1.2 / 70.3.0 versions from the run before the pins landed.
+          # Only the vulnerability DB is worth caching here, not the results.
+          cache: false
 
       # ---- Publish. Everything below is skipped on a dry run. ----
 


### PR DESCRIPTION
The 2.1.0 publish failed its Trivy gate twice on msgpack 1.1.2 and setuptools 70.3.0, after both were pinned to fixed versions. The image did not contain those versions: the build log for the failing run shows 'Successfully installed ... msgpack-1.2.2 ... setuptools-84.0.0', and the only dist-info paths Trivy listed were msgpack-1.2.2 and setuptools-84.0.0.

The image is always built and scanned under the same fixed tag (horilla-hr:smoketest), so trivy-action's result cache can serve findings from a previous run against a different image under that tag. Disabling it costs one DB download per release and removes a gate that can both block a clean image and, worse, pass a dirty one.

docker-ci.yml does not have this problem -- it runs Trivy directly against the built image id with no result caching.

## Description

<!-- What does this PR change, and why? -->

## Checklist

- [ ] **This PR targets `dev/v2.0`, not `2.0`.** GitHub defaults new PRs to `2.0` (the repo default) — change the base branch to `dev/v2.0` before submitting.
- [ ] I've followed the coding conventions in [CONTRIBUTING.md](../CONTRIBUTING.md) (Black + isort, Horilla decorators/`HorillaModel` patterns, etc.)
- [ ] CI (Docker CI + Quality) passes
- [ ] I've linked any related issues

## Related issues

<!-- e.g. Closes #123 -->
