### PR TITLE
fix(dashboard): employee-status series keys were attached to the gender endpoint

### DIFF
--- a/employee/views.py
+++ b/employee/views.py
@@ -3224,6 +3224,10 @@ def dashboard_employee(request):
             },
         ],
         "labels": labels,
+        # Stable, untranslated series keys. Consumers used to derive slice
+        # colours and the drill-down filter from the label text, which only
+        # works while the UI is English.
+        "keys": ["active", "inactive"],
     }
     return JsonResponse(response)
 
@@ -3248,10 +3252,6 @@ def dashboard_employee_gender(request):
             },
         ],
         "labels": labels,
-        # Stable, untranslated series keys. Consumers used to derive slice
-        # colours and the drill-down filter from the label text, which only
-        # works while the UI is English.
-        "keys": ["active", "inactive"],
     }
     return JsonResponse(response)
 


### PR DESCRIPTION
Small follow-up to #1167, spotted while merging 2.1.5 into a downstream fork.

## What's wrong

#1167 added stable, untranslated series keys so the dashboard would stop deriving chart colours and drill-down filters from translated label text. The keys describe the **employee-status** series — `"active"` / `"inactive"` — but on current `dev/v2.0` they sit on `dashboard_employee_gender()` instead of `dashboard_employee()`:

```
dashboard_employee()             lines 3207-3228   "keys": absent
dashboard_employee_gender()      lines 3232-3256   "keys": ["active", "inactive"]
dashboard_employee_department()  lines 3260-3287   "keys": absent
```

The two functions are near-identical in shape — same `response` dict, same `"dataSet"` and `"labels"` keys, same closing lines — which is exactly enough for a hunk to land in the wrong one. (It's the same trap the original change had to be checked for; I hit it in our own merge of that PR too, which is how I recognised it here.)

## Effect today

- `/employee/dashboard-employee/` omits `keys`, so `templates/dashboard.html` falls back to its hardcoded `['active', 'inactive']`. Colours and drill-downs are still correct — but by luck of that fallback, which exists to tolerate an older backend, not to be the normal path.
- `/employee/dashboard-employee-gender/` advertises `keys: ["active", "inactive"]` for a Male/Female/Other series. Nothing reads it today, so nothing is broken; any future consumer that did would be misled.

So: no user-visible bug right now, and the fix is four lines.

## The change

Move the block to the endpoint whose series it describes. No UI change — the template already prefers `data.keys` when it's present.

## Verified

Against current `dev/v2.0` with the patch applied:

```
/employee/dashboard-employee/         labels=['Active', 'In-Active']      keys=['active', 'inactive']
/employee/dashboard-employee-gender/  labels=['Male', 'Female', 'Other']  keys=None
```